### PR TITLE
ci: add workflow_dispatch to scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
   schedule:
     - cron: '0 6 * * 0' # Weekly Sunday 06:00 UTC
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to OpenSSF Scorecard workflow for manual re-runs

## Test plan
- [ ] CI passes
- [ ] Scorecard workflow can be triggered manually after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)