### PR TITLE
chore: SLSA provenance, remove Coveralls, sync living docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing! This guide will help you get starte
 
 ### Prerequisites
 
-- Node.js 18+ (20 recommended)
+- Node.js 20+ (22 recommended)
 - npm 9+
 - An n8n instance for testing (local or Docker)
 
@@ -55,7 +55,8 @@ nodes/BrasilHub/
 ├── types.ts                    # TypeScript interfaces
 ├── shared/
 │   ├── validators.ts           # CNPJ/CEP validation (local, no API)
-│   └── fallback.ts             # Multi-provider fallback logic
+│   ├── fallback.ts             # Multi-provider fallback logic
+│   └── utils.ts                # Shared utilities (stripNonDigits, safeStr)
 └── resources/
     ├── cnpj/                   # CNPJ resource (description, execute, normalize)
     └── cep/                    # CEP resource (description, execute, normalize)
@@ -93,7 +94,6 @@ nodes/BrasilHub/
 
 - TDD approach: write failing test first, then implement
 - Jest + ts-jest
-- Use `jest.useFakeTimers()` for tests involving delays
 - Test normalizers with real API response fixtures per provider
 
 ## Commit Messages

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,8 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.x.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 0.1.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,6 @@ nodes/BrasilHub/
 ## Testing
 
 - TDD: write failing test first, then implement
-- Use `jest.useFakeTimers()` for tests with delays
 - Test normalizers with real API response fixtures per provider
 - Mock `IExecuteFunctions` context for execute handler tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,14 +76,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Run tests
-        run: npx jest --coverage --ci
-
-      - name: Upload coverage to Coveralls
-        if: matrix.node == 20
-        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
-        with:
-          file: ./coverage/lcov.info
-          format: lcov
+        run: npx jest --ci
 
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 # n8n-nodes-brasil-hub Release Pipeline
-# Publishes to npm when a GitHub release is created
+# Build → SLSA Provenance → Publish to npm
+# Provenance (.intoto.jsonl) is attached to GitHub Release for OpenSSF Scorecard
 
 name: Release
 
@@ -11,13 +12,14 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    name: Publish to npm
+  build:
+    name: Build & Pack
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
-      id-token: write
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -43,8 +45,60 @@ jobs:
           test -f dist/nodes/BrasilHub/BrasilHub.node.json
           echo "Build artifacts verified"
 
+      - name: Pack tarball
+        run: npm pack
+
+      - name: Generate hashes
+        id: hash
+        shell: bash
+        run: |
+          echo "hashes=$(sha256sum *.tgz | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: npm-package
+          path: '*.tgz'
+          if-no-files-found: error
+          retention-days: 5
+
+  provenance:
+    name: SLSA Provenance
+    needs: [build]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true
+
+  publish:
+    name: Publish to npm
+    needs: [build, provenance]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download tarball
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: npm-package
+
       - name: Publish to npm
-        run: npm publish --provenance --access public --ignore-scripts
+        run: npm publish *.tgz --provenance --access public --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional raw API response inclusion via `Include Raw Response` toggle
 - `_meta` field with provider info, query timestamp, strategy (`direct`/`fallback`), and errors
 - `usableAsTool: true` for AI Agent compatibility
-- Generic multi-provider fallback engine with 1s delay between retries and 10s timeout
+- Generic multi-provider fallback engine with 10s timeout per provider
 - CNPJ checksum and CEP format validators (zero runtime dependencies)
 - TypeScript strict mode with full type definitions and JSDoc on all 23 public exports
 - 49 tests (99.46% statement coverage) across 8 suites
 - README with installation, operations table, example output, and provider documentation
 - Design spec and implementation plan
-- GitHub Actions CI pipeline (lint, test matrix Node 18/20/22, build, dependency audit)
+- GitHub Actions CI pipeline (lint, test matrix Node 20/22, build, dependency audit)
 - GitHub Actions release pipeline (npm publish with provenance on GitHub release)
 - Community health files (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
 - Issue templates (bug report, feature request) with YAML form schema

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,10 +157,13 @@ This project uses **Manus-style file-based planning** (skill: `planning-with-fil
 ### n8n-node prerelease guard
 - `package.json` tem `"prepublishOnly": "n8n-node prerelease"` (gerado pelo starter template)
 - Este script **bloqueia** `npm publish` direto — exige usar `npm run release` (que faz versioning interno)
-- **Solução CI:** `npm publish --provenance --access public --ignore-scripts` no release workflow
+- **Solução CI:** `npm publish *.tgz --provenance --access public --ignore-scripts` no release workflow
 - O workflow já roda tests + build antes do publish, então pular lifecycle scripts é seguro
 
-### Workflow de release usa código do tag
+### Release pipeline (3 jobs)
+- **Build & Pack** → testa, builda, cria tarball (`npm pack`), gera hash SHA256
+- **SLSA Provenance** → chama `slsa-github-generator` generic generator, anexa `.intoto.jsonl` ao GitHub Release
+- **Publish** → baixa tarball, publica no npm com `--provenance`
 - O `release.yml` roda no ref do tag, não no `main`
 - Se corrigir workflows após criar o tag, precisa **deletar tag + release e recriar** no commit corrigido
 - Ordem correta: CI verde → tag → release (nunca tagar com CI falhando)
@@ -260,6 +263,32 @@ PRE-RELEASE CHECKLIST:
 □ Fase 4: changelog → tag → release
 □ Fase 5: CI release verde → npm publicado
 ```
+
+## Living Docs — Atualizar em Mudanças Estruturais
+
+Estes arquivos contêm informações que ficam desatualizadas quando o projeto muda (Node version, test infra, CI pipeline, arquitetura). **Após qualquer mudança estrutural**, fazer grep pelos termos afetados e propagar para todos.
+
+| Arquivo | O que contém de volátil |
+|---------|------------------------|
+| `README.md` | Badges, Node.js versions, features list |
+| `CLAUDE.md` | Arquitetura, CI/CD pipeline, armadilhas |
+| `.github/CONTRIBUTING.md` | Node.js version, project structure, test guidelines |
+| `.github/copilot-instructions.md` | Arquitetura, test guidelines, code style |
+| `.github/SECURITY.md` | Supported versions |
+| `CHANGELOG.md` | Detalhes técnicos nas entries (test matrix, fallback behavior) |
+| `package.json` | Keywords, engines, scripts |
+| `sonar-project.properties` | Source/test paths, exclusions |
+| `.github/workflows/*.yml` | Node versions, action pins, job structure |
+| `task_plan.md` | Fases, status, erros |
+| `progress.md` | Log de sessão, 5-Question Reboot Check |
+| `findings.md` | Descobertas técnicas |
+
+**Termos para grep após mudanças comuns:**
+- Mudou Node version → grep `Node 18`, `Node 20`, `node-version`, `node:`
+- Mudou test infra → grep `useFakeTimers`, `runWithTimers`, `jest.config`
+- Mudou CI pipeline → grep `coveralls`, `codecov`, `coverage`, workflow names
+- Adicionou arquivo em `shared/` → grep tree structures nos .md
+- Mudou release flow → grep `npm publish`, `provenance`, `release.yml`
 
 ## Spec & Plan
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![npm version](https://img.shields.io/npm/v/n8n-nodes-brasil-hub)](https://www.npmjs.com/package/n8n-nodes-brasil-hub)
 [![CI](https://github.com/luisbarcia/n8n-nodes-brasil-hub/actions/workflows/ci.yml/badge.svg)](https://github.com/luisbarcia/n8n-nodes-brasil-hub/actions/workflows/ci.yml)
-[![Coverage Status](https://coveralls.io/repos/github/luisbarcia/n8n-nodes-brasil-hub/badge.svg?branch=main)](https://coveralls.io/github/luisbarcia/n8n-nodes-brasil-hub?branch=main)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=luisbarcia_n8n-nodes-brasil-hub&metric=alert_status)](https://sonarcloud.io/dashboard?id=luisbarcia_n8n-nodes-brasil-hub)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/luisbarcia/n8n-nodes-brasil-hub/badge)](https://scorecard.dev/viewer/?uri=github.com/luisbarcia/n8n-nodes-brasil-hub)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -123,7 +122,7 @@ npm install n8n-nodes-brasil-hub
 ## Compatibility
 
 - **n8n:** 1.0+
-- **Node.js:** 18, 20, 22
+- **Node.js:** 20, 22
 
 ## Resources
 

--- a/findings.md
+++ b/findings.md
@@ -206,6 +206,51 @@
 - SonarCloud: usuário precisa criar conta + projeto + gerar token
 - **Plano:** configurar os 3 workflows, marcar SonarCloud como pendente de setup manual
 
+## OpenSSF Scorecard Hardening Research
+
+### Score atual: 5.6/10 (18 checks)
+- 7 checks com nota 10 (já perfeitos)
+- 4 checks com nota 0 (acionáveis: Branch-Protection, SAST, CII-Best-Practices, Code-Review)
+- 2 checks inconclusivos (-1: CI-Tests, Signed-Releases)
+- Vulnerabilities: 5/10 (5 vulns conhecidas)
+
+### Branch-Protection (0→10)
+- Scorecard verifica: require PR reviews, status checks, up-to-date, admin enforcement
+- API: `gh api repos/{owner}/{repo}/branches/main/protection -X PUT`
+- Solo dev: pode configurar self-review (PR required mas pode aprovar próprio)
+- Alternativa: Settings → Branches → Add rule no GitHub UI
+
+### SAST (0→10)
+- Scorecard procura especificamente: CodeQL, Semgrep, Snyk, SonarCloud (via SARIF)
+- SonarCloud já roda mas **não faz upload de SARIF para Code Scanning** → Scorecard não detecta
+- CodeQL é o mais simples de adicionar (GitHub nativo, gratuito para public repos)
+- Action: `github/codeql-action/init`, `analyze` — suporta TypeScript via `javascript`
+
+### Vulnerabilities (5→10)
+- Scorecard usa OSV (Open Source Vulnerabilities database)
+- As 5 vulns provavelmente são de devDependencies transitivas (n8n-workflow → langchain chain)
+- Resolver via `npm audit fix` ou atualizar deps
+- Se são apenas devDeps, o Scorecard ainda pode contá-las
+
+### CII-Best-Practices (0→?)
+- URL: https://www.bestpractices.dev/en/projects
+- Questionário: ~60 perguntas sobre qualidade, segurança, documentação
+- Muitas já atendemos (MIT license, CI, tests, security policy, etc.)
+- Badge "passing" requer ~67% das perguntas respondidas positivamente
+- Ação manual do usuário (precisa cadastrar e preencher)
+
+### Signed-Releases (-1→10)
+- Scorecard verifica se releases têm assinaturas (cosign, GPG, Sigstore)
+- npm publish com `--provenance` gera attestation OIDC (Sigstore-based)
+- v0.1.1 já publicou com provenance — o Scorecard pode não ter re-avaliado ainda
+- Alternativa: `gh attestation verify` para confirmar
+
+### Codecov → Coveralls Migration
+- Codecov Project Coverage requer Pro plan ($12/user/mês) — badge ficava "unknown"
+- Coveralls é gratuito para repos públicos, badge mostra 97%
+- Codecov Test Analytics mantido (funciona no free tier)
+- Coveralls action: `coverallsapp/github-action@v2.3.6` com `github-token` automático
+
 ## Resources
 - Spec: `docs/superpowers/specs/2026-03-10-n8n-nodes-brasil-hub-design.md`
 - Plano: `docs/superpowers/plans/2026-03-10-n8n-nodes-brasil-hub.md`

--- a/progress.md
+++ b/progress.md
@@ -175,14 +175,54 @@
 - Errors:
   - scan-community-package: `setTimeout` restricted global no dist/ (eslint-disable do .ts não persiste no .js)
 
+### Phase 10: Quality Badges
+- **Status:** complete
+- **Started:** 2026-03-10
+- Actions taken:
+  - SonarCloud: workflow + sonar-project.properties + badge → Quality Gate Passed
+  - OpenSSF Scorecard: workflow scorecard.yml + badge → 5.6/10
+  - Codecov tentado → Project Coverage requer Pro plan → migrado para Coveralls → removido (SonarCloud já cobre coverage)
+  - Fix SonarCloud findings: safeStr(), Number.parseInt, permissions job-level
+  - Todos os workflows verdes
+- Files created/modified:
+  - `.github/workflows/sonarcloud.yml` (created)
+  - `.github/workflows/scorecard.yml` (created)
+  - `.github/workflows/ci.yml` (modified — coverage removido, SonarCloud cobre)
+  - `sonar-project.properties` (created)
+  - `nodes/BrasilHub/shared/utils.ts` (modified — safeStr())
+  - `nodes/BrasilHub/shared/validators.ts` (modified — Number.parseInt)
+  - `README.md` (modified — badges SonarCloud, OpenSSF)
+- Commits: `c65c8e0`, `9471487`, `2e1fec2`, `6ae3de0`, `14b1dba`, `c16ec7d`, `25ef770`, `31ce1dc`
+
+### Phase 11: OpenSSF Scorecard Hardening (in_progress)
+- **Status:** in_progress
+- **Started:** 2026-03-10
+- **Goal:** Subir score de 5.6 para 8+
+- Actions taken:
+  - Diagnóstico completo: 18 checks, 7 perfeitos, 4 zerados acionáveis
+  - **T2: SAST** — CodeQL workflow criado → SAST 0→10 ✅
+  - **T6: Token-Permissions** — top-level permissions em todos workflows → 9→10 ✅
+  - **T7: CI-Tests** — PRs merged para Scorecard detectar CI → -1→10 ✅
+  - **T1: Branch-Protection** — Migrado de Branch Protection Rules para Repository Rulesets (público via API) → 0→3 (Tier 1: solo dev, sem PR reviews)
+  - **Coveralls removido** — SonarCloud já cobre coverage, badge redundante removido
+  - **T5: Signed-Releases** — SLSA provenance via `slsa-github-generator` generic generator, `.intoto.jsonl` anexado ao GitHub Release → -1→10 (pendente teste)
+  - **Docs atualizados** — README (Node.js 20/22, sem Coveralls badge), CLAUDE.md (release pipeline 3 jobs)
+  - Score subiu de 5.6 → 6.8 (verificado)
+- Files modified nesta sessão:
+  - `.github/workflows/release.yml` (reescrito — 3 jobs: build → provenance → publish)
+  - `.github/workflows/ci.yml` (removido Coveralls step)
+  - `.github/workflows/codeql.yml` (criado na sessão anterior)
+  - `README.md` (removido Coveralls badge, Node.js 20/22)
+  - `CLAUDE.md` (release pipeline 3 jobs com SLSA)
+
 ## 5-Question Reboot Check
 | Question | Answer |
 |----------|--------|
-| Where am I? | Phase 9 in_progress — fixing scan failures for Creator Portal |
-| Where am I going? | Fix setTimeout + aliases → republish → scan pass → Creator Portal |
-| What's the goal? | Node n8n "Brasil Hub" verificado e aceito no Creator Portal |
-| What have I learned? | Ver findings.md — scan tool roda ESLint contra dist/, não honra eslint-disable |
-| What have I done? | 49 tests, 99.46% coverage, v0.1.0 publicado, 2 issues para fix |
+| Where am I? | Phase 11 in_progress — SLSA provenance configurado, falta commit+push+verificar |
+| Where am I going? | Commit → push → verificar CI → próximo release testar provenance |
+| What's the goal? | Subir OpenSSF Scorecard de 5.6 para 8+ (atualmente 6.8) |
+| What have I learned? | SLSA generic generator mantém build próprio + gera .intoto.jsonl; Scorecard checa release assets; solo dev limita Branch-Protection a Tier 1 |
+| What have I done? | CodeQL (SAST 10), Rulesets (Branch 3), Token-Perms (10), CI-Tests (10), SLSA provenance (pendente teste), Coveralls removido |
 
 ---
 *Update after completing each phase or encountering errors*

--- a/task_plan.md
+++ b/task_plan.md
@@ -4,7 +4,7 @@
 Implementar o community node n8n "Brasil Hub" que consulta dados públicos brasileiros (CNPJ e CEP) com fallback multi-provider, seguindo todos os padrões oficiais n8n.
 
 ## Current Phase
-Phase 10 (in_progress) — Quality Badges (Codecov + SonarCloud + OpenSSF Scorecard)
+Phase 11 (in_progress) — OpenSSF Scorecard Hardening (5.6 → 8+)
 
 ## Phases
 
@@ -122,11 +122,59 @@ Phase 10 (in_progress) — Quality Badges (Codecov + SonarCloud + OpenSSF Scorec
 - **Status:** in_progress
 
 ### Phase 10: Quality Badges (Codecov + SonarCloud + OpenSSF Scorecard)
-- [ ] Pesquisar requisitos de cada plataforma
-- [ ] Codecov: adicionar upload step no CI, badge no README
-- [ ] SonarCloud: criar projeto, workflow, sonar-project.properties, badge no README
-- [ ] OpenSSF Scorecard: adicionar workflow oficial, badge no README
-- [ ] Push + CI verde
+- [x] Pesquisar requisitos de cada plataforma
+- [x] Codecov: upload step no CI (codecov-action v5), badge no README
+- [x] SonarCloud: workflow + sonar-project.properties, badge no README
+- [x] OpenSSF Scorecard: workflow oficial (v2.4.3), badge no README
+- [x] Fix SonarCloud findings: safeStr(), Number.parseInt, permissions job-level
+- [x] Todos os 3 workflows verdes
+- **Status:** complete
+
+### Phase 11: OpenSSF Scorecard Hardening (5.6 → 8+)
+**Goal:** Subir score de 5.6 para 8+ atacando os checks acionáveis.
+
+**Scorecard atual (5.6/10):**
+| Check | Score | Acionável? |
+|-------|-------|-----------|
+| Binary-Artifacts | 10 | -- |
+| Dangerous-Workflow | 10 | -- |
+| Dependency-Update-Tool | 10 | -- |
+| License | 10 | -- |
+| Packaging | 10 | -- |
+| Pinned-Dependencies | 10 | -- |
+| Security-Policy | 10 | -- |
+| Token-Permissions | 9 | Minor |
+| Vulnerabilities | 5 | **Sim** |
+| Branch-Protection | 0 | **Sim** |
+| Code-Review | 0 | Parcial (solo dev) |
+| SAST | 0 | **Sim** |
+| CII-Best-Practices | 0 | **Sim** |
+| Fuzzing | 0 | Difícil |
+| Maintained | 0 | Tempo (repo < 90 dias) |
+| Contributors | 0 | Não (solo dev) |
+| CI-Tests | -1 | Precisa de PRs |
+| Signed-Releases | -1 | Timing |
+
+**Tarefas (ordem de impacto):**
+- [ ] **T1: Branch-Protection (0→10)** — Ativar branch protection rules no `main` via `gh api`
+  - Require PR reviews (≥1)
+  - Require status checks (CI, SonarCloud)
+  - Require up-to-date branches
+  - Enforce for admins
+- [ ] **T2: SAST (0→10)** — Adicionar CodeQL Analysis workflow
+  - SonarCloud já roda, mas Scorecard procura CodeQL/Semgrep especificamente
+  - Criar `.github/workflows/codeql.yml`
+- [ ] **T3: Vulnerabilities (5→10)** — Resolver 5 vulnerabilidades conhecidas
+  - Identificar quais são (npm audit, Dependabot alerts)
+  - Atualizar deps ou marcar como devDependency-only
+- [ ] **T4: CII-Best-Practices (0→?)** — Cadastrar no OpenSSF Best Practices
+  - URL: https://www.bestpractices.dev/
+  - Preencher questionário do projeto
+- [ ] **T5: Signed-Releases (-1→10)** — Verificar se v0.1.1 com provenance satisfaz
+  - Se não, criar release com signing explícito
+- [ ] **T6: Token-Permissions (9→10)** — Auditar permissions em todos os workflows
+- [ ] **T7: CI-Tests (-1→?)** — Criar PR de teste para que Scorecard detecte CI checks
+- [ ] Verificar score atualizado no Scorecard
 - **Status:** in_progress
 
 ## Pending


### PR DESCRIPTION
## Summary
- Redesign release pipeline: 3-job flow (build → SLSA provenance → publish) with `.intoto.jsonl` attached to GitHub Releases for OpenSSF Scorecard Signed-Releases check
- Remove Coveralls integration (SonarCloud already covers coverage analysis)
- Fix outdated documentation across 7 files (Node.js versions, removed test infra, project structure)
- Add "Living Docs" section to CLAUDE.md with grep checklist for keeping docs in sync

## Test plan
- [ ] CI passes (lint, test Node 20/22, build)
- [ ] Release pipeline validated on next release (SLSA provenance generates `.intoto.jsonl`)
- [ ] Verify Scorecard re-evaluates Signed-Releases after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)