### PR TITLE
fix: remove paths-ignore from CodeQL PR trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,10 +10,6 @@ on:
       - 'LICENSE'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
   schedule:
     - cron: '0 6 * * 1' # Weekly Monday 6am UTC
 


### PR DESCRIPTION
## Summary

- Remove `paths-ignore` from `pull_request` trigger in `codeql.yml`
- Same fix applied to `ci.yml` in PR #12

## Context

`paths-ignore` on `pull_request` prevents docs-only PRs from triggering the workflow, which means required status checks never report and PRs can't be merged.

## Test plan

- [ ] CI passes on this PR (which includes a workflow change)
- [ ] Future docs-only PRs trigger CodeQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)