### PR TITLE
fix(ci): add private-repository flag to SLSA provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true
+      private-repository: true
 
   publish:
     name: Publish to npm


### PR DESCRIPTION
## Summary

- Add `private-repository: true` to SLSA generator in release workflow
- Fixes SLSA provenance generation failure in v0.1.2 release attempt

## Root cause

The SLSA generator detects the repository as private in release event context and halts to avoid exposing the repo name in the Rekor transparency log. This is a false positive for public repos.

## Test plan

- [ ] CI passes
- [ ] After merge: recreate v0.1.2 tag + release → SLSA provenance generates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)