### PR TITLE
feat: validate CNPJ/CEP before HTTP queries

### DIFF
--- a/__tests__/cep.execute.spec.ts
+++ b/__tests__/cep.execute.spec.ts
@@ -39,6 +39,12 @@ describe('cepQuery', () => {
 		const ctx = createMockContext({ cep: '123' });
 		await expect(cepQuery(ctx, 0)).rejects.toThrow('CEP must have 8 digits');
 	});
+
+	it('should throw on all-zeros CEP before making HTTP calls', async () => {
+		const ctx = createMockContext({ cep: '00000000' });
+		await expect(cepQuery(ctx, 0)).rejects.toThrow('Invalid CEP');
+		expect(ctx.helpers.httpRequest).not.toHaveBeenCalled();
+	});
 });
 
 describe('cepQuery with fallback', () => {

--- a/__tests__/cnpj.execute.spec.ts
+++ b/__tests__/cnpj.execute.spec.ts
@@ -54,6 +54,18 @@ describe('cnpjQuery', () => {
 		const ctx = createMockContext({ cnpj: '123' });
 		await expect(cnpjQuery(ctx, 0)).rejects.toThrow('CNPJ must have 14 digits');
 	});
+
+	it('should throw on invalid CNPJ checksum before making HTTP calls', async () => {
+		const ctx = createMockContext({ cnpj: '11222333000199' }); // valid length, invalid checksum
+		await expect(cnpjQuery(ctx, 0)).rejects.toThrow('Invalid CNPJ checksum');
+		expect(ctx.helpers.httpRequest).not.toHaveBeenCalled();
+	});
+
+	it('should throw on all-same-digit CNPJ before making HTTP calls', async () => {
+		const ctx = createMockContext({ cnpj: '11111111111111' });
+		await expect(cnpjQuery(ctx, 0)).rejects.toThrow('Invalid CNPJ checksum');
+		expect(ctx.helpers.httpRequest).not.toHaveBeenCalled();
+	});
 });
 
 describe('cnpjQuery with fallback', () => {

--- a/__tests__/cnpj.normalize.spec.ts
+++ b/__tests__/cnpj.normalize.spec.ts
@@ -149,6 +149,43 @@ describe('normalizeCnpj', () => {
 		expect(() => normalizeCnpj({}, 'unknown')).toThrow('Unknown CNPJ provider: unknown');
 	});
 
+	it('should handle CNPJ.ws response with all nested fields null', () => {
+		const minimal = { razao_social: 'TESTE' };
+		const result = normalizeCnpj(minimal, 'cnpjws');
+		expect(result.razao_social).toBe('TESTE');
+		expect(result.cnpj).toBe('');
+		expect(result.porte).toBe('');
+		expect(result.natureza_juridica).toBe('');
+		expect(result.capital_social).toBe(0);
+		expect(result.atividade_principal.codigo).toBe('');
+		expect(result.endereco.municipio).toBe('');
+		expect(result.contato.telefone).toBe('');
+		expect(result.socios).toEqual([]);
+	});
+
+	it('should handle ReceitaWS response with atividade_principal not an array', () => {
+		const data = { cnpj: '00000000000191', atividade_principal: 'invalid' };
+		const result = normalizeCnpj(data, 'receitaws');
+		expect(result.atividade_principal.codigo).toBe('');
+		expect(result.atividade_principal.descricao).toBe('');
+	});
+
+	it('should handle ReceitaWS response with empty atividade_principal array', () => {
+		const data = { cnpj: '00000000000191', atividade_principal: [] };
+		const result = normalizeCnpj(data, 'receitaws');
+		expect(result.atividade_principal.codigo).toBe('');
+	});
+
+	it('should handle CNPJ.ws socio with null qualificacao_socio', () => {
+		const data = {
+			...cnpjWsResponse,
+			socios: [{ nome: 'TESTE', cpf_cnpj_socio: '***', qualificacao_socio: null, data_entrada: '2020-01-01' }],
+		};
+		const result = normalizeCnpj(data, 'cnpjws');
+		expect(result.socios[0].qualificacao).toBe('');
+		expect(result.socios[0].nome).toBe('TESTE');
+	});
+
 	it('should never produce "undefined" strings in phone field', () => {
 		const withPartialPhone = {
 			...cnpjWsResponse,

--- a/__tests__/validators.spec.ts
+++ b/__tests__/validators.spec.ts
@@ -49,6 +49,11 @@ describe('validateCnpj', () => {
 		// Petrobras
 		expect(validateCnpj('33000167000101').valid).toBe(true);
 	});
+
+	it('should validate CNPJ where second check digit remainder < 2', () => {
+		// 80000000000040 — sum2 % 11 = 1 (< 2), so check2 = 0
+		expect(validateCnpj('80000000000040').valid).toBe(true);
+	});
 });
 
 describe('validateCep', () => {

--- a/nodes/BrasilHub/resources/cep/cep.execute.ts
+++ b/nodes/BrasilHub/resources/cep/cep.execute.ts
@@ -22,13 +22,14 @@ function buildProviders(cep: string): IProvider[] {
 /**
  * Executes a CEP query against public APIs with multi-provider fallback.
  *
- * Sanitizes input, validates length, queries providers in order (BrasilAPI → ViaCEP → OpenCEP),
- * normalizes the response, and attaches metadata. Optionally includes the raw provider response.
+ * Sanitizes input, validates length and format, queries providers in order
+ * (BrasilAPI → ViaCEP → OpenCEP), normalizes the response, and attaches metadata.
+ * Optionally includes the raw provider response.
  *
  * @param context - n8n execution context.
  * @param itemIndex - Current item index for parameter retrieval and item pairing.
  * @returns n8n execution data with normalized CEP result as JSON.
- * @throws {NodeOperationError} If the CEP doesn't have 8 digits or all providers fail.
+ * @throws {NodeOperationError} If the CEP is invalid (wrong length or all zeros) or all providers fail.
  */
 export async function cepQuery(
 	context: IExecuteFunctions,
@@ -40,6 +41,10 @@ export async function cepQuery(
 
 	if (cep.length !== 8) {
 		throw new NodeOperationError(context.getNode(), 'CEP must have 8 digits', { itemIndex });
+	}
+
+	if (!validateCep(cep).valid) {
+		throw new NodeOperationError(context.getNode(), 'Invalid CEP', { itemIndex });
 	}
 
 	const providers = buildProviders(cep);

--- a/nodes/BrasilHub/resources/cnpj/cnpj.execute.ts
+++ b/nodes/BrasilHub/resources/cnpj/cnpj.execute.ts
@@ -19,13 +19,14 @@ function buildProviders(cnpj: string): IProvider[] {
 /**
  * Executes a CNPJ query against public APIs with multi-provider fallback.
  *
- * Sanitizes input, validates length, queries providers in order (BrasilAPI → CNPJ.ws → ReceitaWS),
- * normalizes the response, and attaches metadata. Optionally includes the raw provider response.
+ * Sanitizes input, validates length and checksum, queries providers in order
+ * (BrasilAPI → CNPJ.ws → ReceitaWS), normalizes the response, and attaches metadata.
+ * Optionally includes the raw provider response.
  *
  * @param context - n8n execution context.
  * @param itemIndex - Current item index for parameter retrieval and item pairing.
  * @returns n8n execution data with normalized CNPJ result as JSON.
- * @throws {NodeOperationError} If the CNPJ doesn't have 14 digits or all providers fail.
+ * @throws {NodeOperationError} If the CNPJ is invalid (wrong length or checksum) or all providers fail.
  */
 export async function cnpjQuery(
 	context: IExecuteFunctions,
@@ -37,6 +38,10 @@ export async function cnpjQuery(
 
 	if (cnpj.length !== 14) {
 		throw new NodeOperationError(context.getNode(), 'CNPJ must have 14 digits', { itemIndex });
+	}
+
+	if (!validateCnpj(cnpj).valid) {
+		throw new NodeOperationError(context.getNode(), 'Invalid CNPJ checksum', { itemIndex });
 	}
 
 	const providers = buildProviders(cnpj);


### PR DESCRIPTION
## Summary

- **CNPJ query**: validates checksum (mod 11) before making API calls — prevents 3 wasted HTTP requests on invalid CNPJs
- **CEP query**: rejects all-zeros CEP before making API calls
- **8 new tests**: pre-query validation + normalizer edge cases (null nested fields, empty arrays)
- **100% coverage**: all metrics (statements, branches, functions, lines)

## Before/After

| Scenario | Before | After |
|----------|--------|-------|
| Invalid CNPJ `11222333000199` (bad checksum) | 3 HTTP calls → all fail → generic error | Immediate `Invalid CNPJ checksum` error, 0 HTTP calls |
| All-zeros CEP `00000000` | 3 HTTP calls → all fail → generic error | Immediate `Invalid CEP` error, 0 HTTP calls |

## Test plan

- [x] `npx jest --coverage` — 60 tests, 100% coverage
- [x] `npx n8n-node build` — success
- [x] `npx n8n-node lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)