### PR TITLE
fix: add author email for Creator Portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-03-11
+
+### Fixed
+- Add author email to package.json (required by n8n Creator Portal for node verification)
+
 ## [0.1.3] - 2026-03-11
 
 ### Added
@@ -79,7 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration (npm + GitHub Actions weekly updates)
 - MIT license
 
-[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.0...v0.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-brasil-hub",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "n8n community node for querying Brazilian public data (CNPJ, CEP) with multi-provider fallback",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",
@@ -18,6 +18,7 @@
   ],
   "author": {
     "name": "Luis Barcia",
+    "email": "barcia.me@proton.me",
     "url": "https://github.com/luisbarcia"
   },
   "bugs": {


### PR DESCRIPTION
## Summary

- Add `email` field to `author` in package.json — required by n8n Creator Portal for node verification
- Bump version to 0.1.4

The Creator Portal returns "Error getting author email from npm" when the package.json `author` object lacks an `email` field.

## Test plan

- [x] No code changes — metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)