### PR TITLE
fix: align package.json with n8n-nodes-starter for Creator Portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-03-11
+
+### Fixed
+- Align package.json with n8n-nodes-starter template to fix Creator Portal vetting
+- Remove unused `main` field and `index.js` entry point (not present in starter template)
+- Change `files` from `["dist/nodes"]` to `["dist"]` to match starter convention
+
 ## [0.1.4] - 2026-03-11
 
 ### Fixed
@@ -84,7 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration (npm + GitHub Actions weekly updates)
 - MIT license
 
-[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.1.1...v0.1.2

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-// n8n community node entry point

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "n8n-nodes-brasil-hub",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "n8n community node for querying Brazilian public data (CNPJ, CEP) with multi-provider fallback",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",
-  "main": "index.js",
   "keywords": [
     "n8n-community-node-package",
     "n8n",
@@ -43,7 +42,7 @@
     "test:watch": "jest --watch"
   },
   "files": [
-    "dist/nodes"
+    "dist"
   ],
   "n8n": {
     "n8nNodesApiVersion": 1,


### PR DESCRIPTION
## Summary
- Remove unused `main: "index.js"` and delete orphan `index.js` (not in starter template)
- Change `files` from `["dist/nodes"]` to `["dist"]` (matches starter convention)
- Bump version to 0.1.5

## Context
Creator Portal vetting failed on v0.1.4 despite local `scan-community-package` passing. Alignment with the official `n8n-nodes-starter` template structure addresses potential structural validation in the portal's backend.

## Test plan
- [x] `npx n8n-node build` passes
- [x] `npx n8n-node lint` passes
- [x] `npx jest --coverage` — 60 tests, 100% coverage
- [ ] `npx @n8n/scan-community-package n8n-nodes-brasil-hub@0.1.5` after publish
- [ ] Creator Portal vetting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)