### PR TITLE
fix: resolve SonarCloud code smells

### DIFF
--- a/nodes/BrasilHub/BrasilHub.node.ts
+++ b/nodes/BrasilHub/BrasilHub.node.ts
@@ -76,8 +76,8 @@ export class BrasilHub implements INodeType {
 
 		for (let i = 0; i < items.length; i++) {
 			try {
-				const resource = this.getNodeParameter('resource', i) as string;
-				const operation = this.getNodeParameter('operation', i) as string;
+				const resource = this.getNodeParameter('resource', i);
+				const operation = this.getNodeParameter('operation', i);
 
 				const handler = resourceOperations[resource]?.[operation];
 				if (!handler) {

--- a/nodes/BrasilHub/shared/utils.ts
+++ b/nodes/BrasilHub/shared/utils.ts
@@ -8,6 +8,7 @@
  * @returns The value as a string, or `''` if null/undefined/object.
  */
 export function safeStr(value: unknown): string {
+	if (typeof value === 'string') return value;
 	if (value == null || typeof value === 'object') return '';
 	return String(value);
 }
@@ -19,5 +20,5 @@ export function safeStr(value: unknown): string {
  * @returns Digits-only string (e.g. `"11222333000181"`).
  */
 export function stripNonDigits(value: string): string {
-	return value.replace(/\D/g, ''); // regex with /g flag = replaceAll
+	return value.replace(/\D/g, ''); // NOSONAR: replaceAll requires es2021 lib, project targets es2019
 }


### PR DESCRIPTION
## Summary
- Remove redundant `as string` type assertions in BrasilHub.node.ts (L79, L80)
- Add early string-type check in `safeStr()` to prevent Object stringification path (L12)
- Add NOSONAR for `replace()` vs `replaceAll()` — project targets es2019, `replaceAll` requires es2021 (L22)

## Context
4 Minor code smells flagged by SonarCloud quality gate. 3 fixed directly, 1 suppressed with justification.

## Test plan
- [x] TypeScript compiles without errors
- [x] All 60 tests passing
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)