### PR TITLE
fix: resolve S6551 in safeStr by narrowing types

### DIFF
--- a/nodes/BrasilHub/shared/utils.ts
+++ b/nodes/BrasilHub/shared/utils.ts
@@ -9,8 +9,8 @@
  */
 export function safeStr(value: unknown): string {
 	if (typeof value === 'string') return value;
-	if (value == null || typeof value === 'object') return '';
-	return String(value);
+	if (typeof value === 'number' || typeof value === 'boolean') return value.toString();
+	return '';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace `String(value)` on `unknown` with explicit `typeof` checks for `string`, `number`, `boolean`
- All other types (object, null, undefined, symbol, bigint) return `''`
- Fixes SonarCloud S6551 (no-base-to-string) that persisted after PR #30

## Test plan
- [x] TypeScript compiles
- [x] All 60 tests passing
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)