### PR TITLE
refactor: reduce cognitive complexity and use replaceAll

### DIFF
--- a/nodes/BrasilHub/BrasilHub.node.ts
+++ b/nodes/BrasilHub/BrasilHub.node.ts
@@ -1,5 +1,6 @@
 import type {
 	IExecuteFunctions,
+	INode,
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
@@ -26,6 +27,27 @@ type ExecuteFunction = (
  * Dictionary map routing resource+operation pairs to their execute handlers.
  * Adding a new resource or operation only requires a new entry here.
  */
+/** Builds an error output item for continueOnFail mode. */
+function buildFailItem(node: INode, error: unknown, itemIndex: number): INodeExecutionData {
+	const nodeError = error instanceof NodeOperationError
+		? error
+		: new NodeOperationError(node, error as Error, { itemIndex });
+	return {
+		json: { error: error instanceof Error ? error.message : String(error) },
+		error: nodeError,
+		pairedItem: { item: itemIndex },
+	};
+}
+
+/** Re-throws an error with itemIndex attached to its context. */
+function rethrowWithContext(node: INode, error: unknown, itemIndex: number): never {
+	if ((error as Record<string, unknown>).context) {
+		(error as Record<string, unknown> & { context: Record<string, unknown> }).context.itemIndex = itemIndex;
+		throw error;
+	}
+	throw new NodeOperationError(node, error as Error, { itemIndex });
+}
+
 const resourceOperations: Record<string, Record<string, ExecuteFunction>> = {
 	cnpj: { query: cnpjQuery, validate: cnpjValidate },
 	cep: { query: cepQuery, validate: cepValidate },
@@ -109,21 +131,10 @@ export class BrasilHub implements INodeType {
 				returnData.push(...results);
 			} catch (error) {
 				if (this.continueOnFail()) {
-					const nodeError = error instanceof NodeOperationError
-						? error
-						: new NodeOperationError(this.getNode(), error as Error, { itemIndex: i });
-					returnData.push({
-						json: { error: error instanceof Error ? error.message : String(error) },
-						error: nodeError,
-						pairedItem: { item: i },
-					});
+					returnData.push(buildFailItem(this.getNode(), error, i));
 					continue;
 				}
-				if ((error as Record<string, unknown>).context) {
-					(error as Record<string, unknown> & { context: Record<string, unknown> }).context.itemIndex = i;
-					throw error;
-				}
-				throw new NodeOperationError(this.getNode(), error as Error, { itemIndex: i });
+				rethrowWithContext(this.getNode(), error, i);
 			}
 		}
 

--- a/nodes/BrasilHub/shared/utils.ts
+++ b/nodes/BrasilHub/shared/utils.ts
@@ -47,6 +47,6 @@ export function buildMeta(provider: string, query: string, errors: string[]): {
  * @returns Digits-only string (e.g. `"11222333000181"`).
  */
 export function stripNonDigits(value: string): string {
-	if (typeof value !== 'string') return String(value ?? '').replace(/\D/g, '');
-	return value.replace(/\D/g, ''); // NOSONAR: replaceAll requires es2021 lib, project targets es2019
+	if (typeof value !== 'string') return String(value ?? '').replaceAll(/\D/g, '');
+	return value.replaceAll(/\D/g, '');
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es2019",
-    "lib": ["es2019", "es2020", "es2022.error"],
+    "lib": ["es2019", "es2020", "es2021", "es2022.error"],
     "removeComments": true,
     "useUnknownInCatchVariables": false,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- Extract `buildFailItem()` and `rethrowWithContext()` from `execute()` catch block
- Reduces Cognitive Complexity from 19 → ~8 (SonarCloud S3776)
- Replace `String#replace()` with `String#replaceAll()` (SonarCloud S6582)
- Add `es2021` to tsconfig lib (Node 20+ supports replaceAll natively)

## Test plan
- [x] All 374 tests pass
- [x] Build succeeds

Closes SonarCloud code smells: brain-overload (Critical), es2021 readability (Minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)