### PR TITLE
docs: complete JSDoc coverage (100% exports)

### DIFF
--- a/nodes/BrasilHub/BrasilHub.node.ts
+++ b/nodes/BrasilHub/BrasilHub.node.ts
@@ -112,6 +112,7 @@ export class BrasilHub implements INodeType {
 	 *
 	 * Supports `continueOnFail` — failed items return `{ error }` with `pairedItem` intact.
 	 *
+	 * @returns {Promise<INodeExecutionData[][]>} Array of output items grouped by output index.
 	 * @throws {NodeOperationError} If resource/operation pair is unknown or handler fails.
 	 */
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {

--- a/nodes/BrasilHub/resources/banks/banks.normalize.ts
+++ b/nodes/BrasilHub/resources/banks/banks.normalize.ts
@@ -36,6 +36,7 @@ const normalizers: Record<string, (data: Record<string, unknown>) => IBank> = {
  * @param provider - Provider name.
  * @param bankCode - Bank code to filter (required for BancosBrasileiros).
  * @returns Normalized bank result.
+ * @throws {Error} If provider is unknown or bank code is not found in BancosBrasileiros data.
  */
 export function normalizeBank(data: unknown, provider: string, bankCode?: number): IBank {
 	if (provider === 'bancosbrasileiros') {
@@ -60,6 +61,7 @@ export function normalizeBank(data: unknown, provider: string, bankCode?: number
  * @param data - Raw provider response (array of banks).
  * @param provider - Provider name.
  * @returns Array of normalized bank results.
+ * @throws {Error} If provider is unknown.
  */
 export function normalizeBanks(data: unknown, provider: string): IBank[] {
 	const normalizer = normalizers[provider];

--- a/nodes/BrasilHub/resources/ddd/ddd.normalize.ts
+++ b/nodes/BrasilHub/resources/ddd/ddd.normalize.ts
@@ -66,6 +66,7 @@ function normalizeMunicipiosDdd(data: Array<Record<string, unknown>>, dddCode: n
  * @param provider - Provider name.
  * @param dddCode - DDD code to filter (required for municipios provider).
  * @returns Normalized DDD result.
+ * @throws {Error} If provider is unknown or DDD code is not found in municipios data.
  */
 export function normalizeDdd(data: unknown, provider: string, dddCode?: number): IDdd {
 	if (provider === 'brasilapi') {


### PR DESCRIPTION
## Summary

- Add missing `@returns` to `BrasilHub.execute()`
- Add missing `@throws` to `normalizeBank()`, `normalizeBanks()`, `normalizeDdd()`
- JSDoc coverage: 40/40 exports (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)