### PR TITLE
fix(security): runtime timeout clamping — v0.10.1

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -5,6 +5,7 @@
 | Version | Supported          |
 | ------- | ------------------ |
 | 0.10.x  | :white_check_mark: |
+| 0.10.0  | :x: (no runtime timeout clamping) |
 | < 0.10  | :x:                |
 
 ## Reporting a Vulnerability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-03-17
+
+### Fixed
+- **Runtime timeout clamping** — timeout values are now clamped to [1000, 60000] ms at runtime, not just UI
+  - Prevents `timeout: 0` (infinite wait in axios) via expressions or AI tool usage
+  - NaN/Infinity values fall back to DEFAULT_TIMEOUT_MS (10000)
+  - `clampTimeout()` guard applied in both `queryWithFallback` and `fetchFipe`
+
+### Changed
+- Exported `DEFAULT_TIMEOUT_MS` constant — all 9 resource handlers now import it instead of hardcoding `10000` (single source of truth)
+- 13 new boundary tests for `clampTimeout` + `queryWithFallback` edge cases
+- 1154 tests total (was 1141)
+
 ## [0.10.0] - 2026-03-17
 
 ### Added
@@ -315,7 +328,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration (npm + GitHub Actions weekly updates)
 - MIT license
 
-[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.7.0...v0.8.0

--- a/__tests__/fallback.spec.ts
+++ b/__tests__/fallback.spec.ts
@@ -1,4 +1,4 @@
-import { queryWithFallback } from '../nodes/BrasilHub/shared/fallback';
+import { queryWithFallback, clampTimeout, DEFAULT_TIMEOUT_MS, MIN_TIMEOUT_MS, MAX_TIMEOUT_MS } from '../nodes/BrasilHub/shared/fallback';
 import { buildMeta } from '../nodes/BrasilHub/shared/utils';
 import type { IProvider } from '../nodes/BrasilHub/types';
 
@@ -106,6 +106,62 @@ describe('queryWithFallback', () => {
 		);
 	});
 
+	it('should clamp timeout=0 to MIN_TIMEOUT_MS', async () => {
+		const ctx = createMockContext([{ success: true, data: { ok: true } }]);
+		await queryWithFallback(ctx, providers, 0);
+		expect(ctx.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: MIN_TIMEOUT_MS }),
+		);
+	});
+
+	it('should clamp negative timeout to MIN_TIMEOUT_MS', async () => {
+		const ctx = createMockContext([{ success: true, data: { ok: true } }]);
+		await queryWithFallback(ctx, providers, -1);
+		expect(ctx.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: MIN_TIMEOUT_MS }),
+		);
+	});
+
+	it('should clamp timeout exceeding MAX to MAX_TIMEOUT_MS', async () => {
+		const ctx = createMockContext([{ success: true, data: { ok: true } }]);
+		await queryWithFallback(ctx, providers, 999999);
+		expect(ctx.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: MAX_TIMEOUT_MS }),
+		);
+	});
+
+	it('should clamp NaN timeout to DEFAULT_TIMEOUT_MS', async () => {
+		const ctx = createMockContext([{ success: true, data: { ok: true } }]);
+		await queryWithFallback(ctx, providers, NaN);
+		expect(ctx.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: DEFAULT_TIMEOUT_MS }),
+		);
+	});
+
+	it('should clamp Infinity timeout to DEFAULT_TIMEOUT_MS', async () => {
+		const ctx = createMockContext([{ success: true, data: { ok: true } }]);
+		await queryWithFallback(ctx, providers, Infinity);
+		expect(ctx.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: DEFAULT_TIMEOUT_MS }),
+		);
+	});
+
+	it('should accept MIN_TIMEOUT_MS boundary value', async () => {
+		const ctx = createMockContext([{ success: true, data: { ok: true } }]);
+		await queryWithFallback(ctx, providers, MIN_TIMEOUT_MS);
+		expect(ctx.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: MIN_TIMEOUT_MS }),
+		);
+	});
+
+	it('should accept MAX_TIMEOUT_MS boundary value', async () => {
+		const ctx = createMockContext([{ success: true, data: { ok: true } }]);
+		await queryWithFallback(ctx, providers, MAX_TIMEOUT_MS);
+		expect(ctx.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ timeout: MAX_TIMEOUT_MS }),
+		);
+	});
+
 	it('should collect all error messages from failed providers', async () => {
 		const ctx = createMockContext([
 			{ success: false, error: 'Timeout' },
@@ -118,6 +174,37 @@ describe('queryWithFallback', () => {
 			'provider1: Timeout',
 			'provider2: 404 Not Found',
 		]);
+	});
+});
+
+describe('clampTimeout', () => {
+	it('should return value within valid range unchanged', () => {
+		expect(clampTimeout(5000)).toBe(5000);
+	});
+
+	it('should clamp below minimum to MIN_TIMEOUT_MS', () => {
+		expect(clampTimeout(500)).toBe(MIN_TIMEOUT_MS);
+		expect(clampTimeout(0)).toBe(MIN_TIMEOUT_MS);
+		expect(clampTimeout(-100)).toBe(MIN_TIMEOUT_MS);
+	});
+
+	it('should clamp above maximum to MAX_TIMEOUT_MS', () => {
+		expect(clampTimeout(100000)).toBe(MAX_TIMEOUT_MS);
+		expect(clampTimeout(60001)).toBe(MAX_TIMEOUT_MS);
+	});
+
+	it('should return DEFAULT for NaN', () => {
+		expect(clampTimeout(NaN)).toBe(DEFAULT_TIMEOUT_MS);
+	});
+
+	it('should return DEFAULT for Infinity', () => {
+		expect(clampTimeout(Infinity)).toBe(DEFAULT_TIMEOUT_MS);
+		expect(clampTimeout(-Infinity)).toBe(DEFAULT_TIMEOUT_MS);
+	});
+
+	it('should accept exact boundary values', () => {
+		expect(clampTimeout(MIN_TIMEOUT_MS)).toBe(MIN_TIMEOUT_MS);
+		expect(clampTimeout(MAX_TIMEOUT_MS)).toBe(MAX_TIMEOUT_MS);
 	});
 });
 

--- a/nodes/BrasilHub/resources/banks/banks.execute.ts
+++ b/nodes/BrasilHub/resources/banks/banks.execute.ts
@@ -2,7 +2,7 @@ import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import type { IProvider } from '../../types';
 import { buildMeta, buildResultItem, buildResultItems } from '../../shared/utils';
-import { queryWithFallback } from '../../shared/fallback';
+import { queryWithFallback, DEFAULT_TIMEOUT_MS } from '../../shared/fallback';
 import { normalizeBank, normalizeBanks } from './banks.normalize';
 
 const BANKS_LIST_PROVIDERS: IProvider[] = [
@@ -37,7 +37,7 @@ export async function banksQuery(
 ): Promise<INodeExecutionData[]> {
 	const bankCodeInput = context.getNodeParameter('bankCode', itemIndex) as string;
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 	const bankCode = Number.parseInt(bankCodeInput, 10);
 
 	if (!Number.isInteger(bankCode) || bankCode <= 0) {
@@ -73,7 +73,7 @@ export async function banksList(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 
 	const result = await queryWithFallback(context, BANKS_LIST_PROVIDERS, timeoutMs);
 

--- a/nodes/BrasilHub/resources/cep/cep.execute.ts
+++ b/nodes/BrasilHub/resources/cep/cep.execute.ts
@@ -3,7 +3,7 @@ import { NodeOperationError } from 'n8n-workflow';
 import type { IProvider } from '../../types';
 import { buildMeta, buildResultItem } from '../../shared/utils';
 import { validateCep, sanitizeCep } from '../../shared/validators';
-import { queryWithFallback } from '../../shared/fallback';
+import { queryWithFallback, DEFAULT_TIMEOUT_MS } from '../../shared/fallback';
 import { normalizeCep } from './cep.normalize';
 
 const CEP_PROVIDERS: IProvider[] = [
@@ -43,7 +43,7 @@ export async function cepQuery(
 ): Promise<INodeExecutionData[]> {
 	const cepInput = context.getNodeParameter('cep', itemIndex) as string;
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 	const cep = sanitizeCep(cepInput);
 
 	if (cep.length !== 8) {

--- a/nodes/BrasilHub/resources/cnpj/cnpj.execute.ts
+++ b/nodes/BrasilHub/resources/cnpj/cnpj.execute.ts
@@ -3,7 +3,7 @@ import { NodeOperationError } from 'n8n-workflow';
 import type { IProvider } from '../../types';
 import { buildMeta, buildResultItem } from '../../shared/utils';
 import { validateCnpj, sanitizeCnpj } from '../../shared/validators';
-import { queryWithFallback } from '../../shared/fallback';
+import { queryWithFallback, DEFAULT_TIMEOUT_MS } from '../../shared/fallback';
 import { normalizeCnpj } from './cnpj.normalize';
 
 const CNPJ_PROVIDERS: IProvider[] = [
@@ -40,7 +40,7 @@ export async function cnpjQuery(
 	const cnpjInput = context.getNodeParameter('cnpj', itemIndex) as string;
 	const simplify = context.getNodeParameter('simplify', itemIndex, true) as boolean;
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 	const cnpj = sanitizeCnpj(cnpjInput);
 
 	if (cnpj.length !== 14) {

--- a/nodes/BrasilHub/resources/ddd/ddd.execute.ts
+++ b/nodes/BrasilHub/resources/ddd/ddd.execute.ts
@@ -2,7 +2,7 @@ import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import type { IProvider } from '../../types';
 import { buildMeta, buildResultItem } from '../../shared/utils';
-import { queryWithFallback } from '../../shared/fallback';
+import { queryWithFallback, DEFAULT_TIMEOUT_MS } from '../../shared/fallback';
 import { normalizeDdd } from './ddd.normalize';
 
 /**
@@ -22,7 +22,7 @@ export async function dddQuery(
 ): Promise<INodeExecutionData[]> {
 	const dddInput = context.getNodeParameter('ddd', itemIndex) as string;
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 	const ddd = Number.parseInt(dddInput, 10);
 
 	if (!Number.isInteger(ddd) || ddd < 11 || ddd > 99) {

--- a/nodes/BrasilHub/resources/feriados/feriados.execute.ts
+++ b/nodes/BrasilHub/resources/feriados/feriados.execute.ts
@@ -2,7 +2,7 @@ import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import type { IProvider } from '../../types';
 import { buildMeta, buildResultItems } from '../../shared/utils';
-import { queryWithFallback } from '../../shared/fallback';
+import { queryWithFallback, DEFAULT_TIMEOUT_MS } from '../../shared/fallback';
 import { normalizeFeriados } from './feriados.normalize';
 
 /**
@@ -36,7 +36,7 @@ export async function feriadosQuery(
 ): Promise<INodeExecutionData[]> {
 	const year = context.getNodeParameter('year', itemIndex) as number;
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 
 	if (!Number.isInteger(year) || year < 1900 || year > 2199) {
 		throw new NodeOperationError(

--- a/nodes/BrasilHub/resources/fipe/fipe.execute.ts
+++ b/nodes/BrasilHub/resources/fipe/fipe.execute.ts
@@ -1,6 +1,7 @@
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import { buildMeta, buildResultItem, buildResultItems } from '../../shared/utils';
+import { clampTimeout, DEFAULT_TIMEOUT_MS } from '../../shared/fallback';
 import { normalizeBrands, normalizeModels, normalizeYears, normalizePrice } from './fipe.normalize';
 
 const BASE_URL = 'https://parallelum.com.br/fipe/api/v1';
@@ -45,13 +46,13 @@ function getCommonParams(context: IExecuteFunctions, itemIndex: number) {
 	const vehicleType = context.getNodeParameter('vehicleType', itemIndex) as string;
 	const referenceTable = context.getNodeParameter('referenceTable', itemIndex, 0) as number;
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 	validateVehicleType(context, vehicleType, itemIndex);
 	return { vehicleType, referenceTable, includeRaw, timeoutMs };
 }
 
 /** Performs a single HTTP GET to parallelum. */
-async function fetchFipe(context: IExecuteFunctions, url: string, timeoutMs = 10000): Promise<unknown> {
+async function fetchFipe(context: IExecuteFunctions, url: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<unknown> {
 	return context.helpers.httpRequest({
 		method: 'GET',
 		url,
@@ -59,7 +60,7 @@ async function fetchFipe(context: IExecuteFunctions, url: string, timeoutMs = 10
 			Accept: 'application/json',
 			'User-Agent': 'n8n-brasil-hub-node/1.0',
 		},
-		timeout: timeoutMs,
+		timeout: clampTimeout(timeoutMs),
 	});
 }
 

--- a/nodes/BrasilHub/resources/ibge/ibge.execute.ts
+++ b/nodes/BrasilHub/resources/ibge/ibge.execute.ts
@@ -2,7 +2,7 @@ import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import type { IProvider } from '../../types';
 import { buildMeta, buildResultItems } from '../../shared/utils';
-import { queryWithFallback } from '../../shared/fallback';
+import { queryWithFallback, DEFAULT_TIMEOUT_MS } from '../../shared/fallback';
 import { normalizeStates, normalizeCities } from './ibge.normalize';
 
 const VALID_UFS = new Set([
@@ -42,7 +42,7 @@ export async function ibgeStates(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 
 	const result = await queryWithFallback(context, STATES_PROVIDERS, timeoutMs);
 	const states = normalizeStates(result.data, result.provider);
@@ -66,7 +66,7 @@ export async function ibgeCities(
 ): Promise<INodeExecutionData[]> {
 	const ufInput = (context.getNodeParameter('uf', itemIndex) as string).toUpperCase().trim();
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 
 	if (!VALID_UFS.has(ufInput)) {
 		throw new NodeOperationError(

--- a/nodes/BrasilHub/resources/ncm/ncm.execute.ts
+++ b/nodes/BrasilHub/resources/ncm/ncm.execute.ts
@@ -1,7 +1,7 @@
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import { buildMeta, buildResultItem, buildResultItems } from '../../shared/utils';
-import { queryWithFallback } from '../../shared/fallback';
+import { queryWithFallback, DEFAULT_TIMEOUT_MS } from '../../shared/fallback';
 import { normalizeNcm, normalizeNcmList } from './ncm.normalize';
 
 /**
@@ -18,7 +18,7 @@ export async function ncmQuery(
 ): Promise<INodeExecutionData[]> {
 	const ncmCode = (context.getNodeParameter('ncmCode', itemIndex) as string).trim();
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 
 	if (!ncmCode) {
 		throw new NodeOperationError(context.getNode(), 'NCM code is required', { itemIndex });
@@ -48,7 +48,7 @@ export async function ncmSearch(
 ): Promise<INodeExecutionData[]> {
 	const searchTerm = (context.getNodeParameter('searchTerm', itemIndex) as string).trim();
 	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, 10000) as number;
+	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 
 	if (searchTerm.length < 3) {
 		throw new NodeOperationError(

--- a/nodes/BrasilHub/shared/fallback.ts
+++ b/nodes/BrasilHub/shared/fallback.ts
@@ -2,7 +2,19 @@ import type { IExecuteFunctions } from 'n8n-workflow';
 import type { IProvider, IFallbackResult } from '../types';
 
 /** Default HTTP request timeout in milliseconds per provider attempt. */
-const DEFAULT_TIMEOUT_MS = 10000;
+export const DEFAULT_TIMEOUT_MS = 10000;
+
+/** Minimum allowed timeout in milliseconds. */
+export const MIN_TIMEOUT_MS = 1000;
+
+/** Maximum allowed timeout in milliseconds. */
+export const MAX_TIMEOUT_MS = 60000;
+
+/** Clamps a timeout value to the allowed range [MIN_TIMEOUT_MS, MAX_TIMEOUT_MS]. */
+export function clampTimeout(value: number): number {
+	const n = Number.isFinite(value) ? value : DEFAULT_TIMEOUT_MS;
+	return Math.max(MIN_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, n));
+}
 
 /**
  * Queries multiple providers in sequence until one succeeds (fallback strategy).
@@ -22,6 +34,7 @@ export async function queryWithFallback(
 	providers: IProvider[],
 	timeoutMs: number = DEFAULT_TIMEOUT_MS,
 ): Promise<IFallbackResult> {
+	const safeTimeout = clampTimeout(timeoutMs);
 	const errors: string[] = [];
 
 	for (const provider of providers) {
@@ -33,7 +46,7 @@ export async function queryWithFallback(
 					Accept: 'application/json',
 					'User-Agent': 'n8n-brasil-hub-node/1.0',
 				},
-				timeout: timeoutMs,
+				timeout: safeTimeout,
 			});
 
 			return { data, provider: provider.name, errors };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-brasil-hub",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "n8n community node for querying Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Feriados, FIPE, IBGE, NCM) with multi-provider fallback",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",


### PR DESCRIPTION
## Summary
- Runtime `clampTimeout()` guard prevents `timeout: 0` (infinite wait in axios) via expressions/AI tool bypass
- NaN/Infinity → DEFAULT_TIMEOUT_MS, all values clamped to [1000, 60000] ms
- Exported `DEFAULT_TIMEOUT_MS` constant — all 9 handlers import it (single source of truth)
- 13 new boundary tests, 1154 total

## Test plan
- [x] `clampTimeout(0)` → 1000
- [x] `clampTimeout(-1)` → 1000
- [x] `clampTimeout(NaN)` → 10000
- [x] `clampTimeout(Infinity)` → 10000
- [x] `clampTimeout(999999)` → 60000
- [x] Boundary values 1000 and 60000 accepted
- [x] `queryWithFallback` applies clamp before httpRequest

🤖 Generated with [Claude Code](https://claude.com/claude-code)