### PR TITLE
feat: add CNPJ Output Mode (AI Summary) — v0.11.0

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.10.x  | :white_check_mark: |
+| 0.11.x  | :white_check_mark: |
+| 0.10.1  | :white_check_mark: |
 | 0.10.0  | :x: (no runtime timeout clamping) |
 | < 0.10  | :x:                |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-03-17
+
+### Added
+- **CNPJ Output Mode** — new `Output Mode` dropdown when Simplify is disabled
+  - **Full** (default): all normalized fields (address, contacts, partners)
+  - **AI Summary**: 8 flat English key-value fields optimized for AI Agent tool usage
+    (`cnpj`, `company`, `trade_name`, `status`, `since`, `size`, `activity`, `city`)
+- 4 new output mode tests in cnpj.execute.spec.ts
+
+### Changed
+- 1158 tests total (was 1154)
+- Backward-compatible: existing workflows with `simplify: true/false` keep working identically
+
 ## [0.10.1] - 2026-03-17
 
 ### Fixed
@@ -328,7 +341,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration (npm + GitHub Actions weekly updates)
 - MIT license
 
-[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.10.1...HEAD
+[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.8.0...v0.9.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,7 @@ Each new resource ships as its own MINOR release for faster iteration and easier
 - [ ] **Configurable Provider Order** — User chooses primary provider per resource
 - [x] **Configurable Timeout** — Override default 10s timeout per operation
 - [ ] **Rate Limit Awareness** — Detect HTTP 429, retry with exponential backoff
-- [ ] **CNPJ Output Mode** — Simplified (default), Full, AI Summary
+- [x] **CNPJ Output Mode** — Simplified (default), Full, AI Summary
 - [ ] **Creator Portal resubmission** — Submit stable v1.0.0 for "Verified" badge
 - [ ] Comprehensive documentation site or wiki
 

--- a/__tests__/cnpj.execute.spec.ts
+++ b/__tests__/cnpj.execute.spec.ts
@@ -68,6 +68,54 @@ describe('cnpjQuery', () => {
 	});
 });
 
+describe('cnpjQuery output modes', () => {
+	it('should return simplified output when simplify=true (default)', async () => {
+		const ctx = createMockContext({ simplify: true });
+		const [result] = await cnpjQuery(ctx, 0);
+		expect(result.json).toHaveProperty('cnpj');
+		expect(result.json).toHaveProperty('razao_social');
+		expect(result.json).toHaveProperty('situacao');
+		expect(result.json).not.toHaveProperty('endereco');
+		expect(result.json).not.toHaveProperty('socios');
+		expect(result.json).not.toHaveProperty('company');
+	});
+
+	it('should return full output when simplify=false and outputMode=full', async () => {
+		const ctx = createMockContext({ simplify: false, outputMode: 'full' });
+		const [result] = await cnpjQuery(ctx, 0);
+		expect(result.json).toHaveProperty('cnpj');
+		expect(result.json).toHaveProperty('razao_social');
+		expect(result.json).toHaveProperty('endereco');
+		expect(result.json).toHaveProperty('contato');
+		expect(result.json).toHaveProperty('socios');
+	});
+
+	it('should return AI Summary when simplify=false and outputMode=aiSummary', async () => {
+		const ctx = createMockContext({ simplify: false, outputMode: 'aiSummary' });
+		const [result] = await cnpjQuery(ctx, 0);
+		expect(result.json).toHaveProperty('cnpj', '11222333000181');
+		expect(result.json).toHaveProperty('company', 'EMPRESA TESTE');
+		expect(result.json).toHaveProperty('trade_name', '');
+		expect(result.json).toHaveProperty('status', 'ATIVA');
+		expect(result.json).toHaveProperty('since', '2020-01-01');
+		expect(result.json).toHaveProperty('size', 'ME');
+		expect(result.json).toHaveProperty('activity', 'Desenvolvimento de software (6201501)');
+		expect(result.json).toHaveProperty('city', 'SAO PAULO/SP');
+		// Should NOT have nested objects
+		expect(result.json).not.toHaveProperty('endereco');
+		expect(result.json).not.toHaveProperty('socios');
+		expect(result.json).not.toHaveProperty('razao_social');
+		expect(result.json).toHaveProperty('_meta');
+	});
+
+	it('should default to full when simplify=false and outputMode not set', async () => {
+		const ctx = createMockContext({ simplify: false });
+		const [result] = await cnpjQuery(ctx, 0);
+		expect(result.json).toHaveProperty('endereco');
+		expect(result.json).toHaveProperty('socios');
+	});
+});
+
 describe('cnpjQuery with fallback', () => {
 	it('should set strategy to fallback when first provider fails', async () => {
 		let callCount = 0;

--- a/nodes/BrasilHub/BrasilHub.node.json
+++ b/nodes/BrasilHub/BrasilHub.node.json
@@ -6,7 +6,7 @@
 	"subcategories": {
 		"Data & Storage": ["Request Making"]
 	},
-	"alias": ["brazil", "cnpj", "cpf", "cep", "banks", "ddd", "feriados", "holidays", "fipe", "vehicle", "ibge", "states", "cities", "ncm", "tax-classification", "area-code", "tax-id", "zip-code", "address", "company", "timeout"],
+	"alias": ["brazil", "cnpj", "cpf", "cep", "banks", "ddd", "feriados", "holidays", "fipe", "vehicle", "ibge", "states", "cities", "ncm", "tax-classification", "area-code", "tax-id", "zip-code", "address", "company", "timeout", "ai-summary"],
 	"resources": {
 		"primaryDocumentation": [
 			{

--- a/nodes/BrasilHub/resources/cnpj/cnpj.description.ts
+++ b/nodes/BrasilHub/resources/cnpj/cnpj.description.ts
@@ -51,6 +51,26 @@ export const cnpjDescription: INodeProperties[] = [
 		description: 'Whether to return a simplified response with only the most important fields',
 	},
 	{
+		displayName: 'Output Mode',
+		name: 'outputMode',
+		type: 'options',
+		displayOptions: { show: { resource: ['cnpj'], operation: ['query'], simplify: [false] } },
+		options: [
+			{
+				name: 'Full',
+				value: 'full',
+				description: 'All normalized fields including address, contacts, and partners',
+			},
+			{
+				name: 'AI Summary',
+				value: 'aiSummary',
+				description: 'Flat key-value object optimized for AI Agent tool usage',
+			},
+		],
+		default: 'full',
+		description: 'Output format when Simplify is disabled',
+	},
+	{
 		displayName: 'Include Raw Response',
 		name: 'includeRaw',
 		type: 'boolean',

--- a/nodes/BrasilHub/resources/cnpj/cnpj.execute.ts
+++ b/nodes/BrasilHub/resources/cnpj/cnpj.execute.ts
@@ -56,12 +56,27 @@ export async function cnpjQuery(
 
 	const full = normalizeCnpj(result.data, result.provider);
 	const meta = buildMeta(result.provider, cnpj, result.errors);
+	const outputMode = simplify ? 'simplified' : (context.getNodeParameter('outputMode', itemIndex, 'full') as string);
 
-	const normalized = simplify
-		? { cnpj: full.cnpj, razao_social: full.razao_social, nome_fantasia: full.nome_fantasia, situacao: full.situacao, data_abertura: full.data_abertura, porte: full.porte }
-		: full;
+	let normalized: Record<string, unknown>;
+	if (outputMode === 'simplified') {
+		normalized = { cnpj: full.cnpj, razao_social: full.razao_social, nome_fantasia: full.nome_fantasia, situacao: full.situacao, data_abertura: full.data_abertura, porte: full.porte };
+	} else if (outputMode === 'aiSummary') {
+		normalized = {
+			cnpj: full.cnpj,
+			company: full.razao_social,
+			trade_name: full.nome_fantasia,
+			status: full.situacao,
+			since: full.data_abertura,
+			size: full.porte,
+			activity: full.atividade_principal ? `${full.atividade_principal.descricao} (${full.atividade_principal.codigo})` : '',
+			city: full.endereco ? `${full.endereco.municipio}/${full.endereco.uf}` : '',
+		};
+	} else {
+		normalized = full as unknown as Record<string, unknown>;
+	}
 
-	return buildResultItem(normalized as unknown as Record<string, unknown>, meta, result.data, includeRaw, itemIndex) as INodeExecutionData[];
+	return buildResultItem(normalized, meta, result.data, includeRaw, itemIndex) as INodeExecutionData[];
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-brasil-hub",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "n8n community node for querying Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Feriados, FIPE, IBGE, NCM) with multi-provider fallback",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",

--- a/task_plan.md
+++ b/task_plan.md
@@ -415,8 +415,10 @@ Each new resource ships as its own MINOR release:
 - [ ] Respeitar header `Retry-After` se presente
 
 #### 24.4 CNPJ Output Mode
-- [ ] Param "Output Mode": Simplified (default), Full, AI Summary
-- [ ] AI Summary: campos otimizados para usableAsTool (1-liner por campo)
+- [x] Param "Output Mode": Full (default), AI Summary — appears when Simplify is disabled
+- [x] AI Summary: 8 flat English key-value fields (cnpj, company, trade_name, status, since, size, activity, city)
+- [x] Backward-compatible: simplify=true/false unchanged
+- [x] 4 new tests, released as v0.11.0
 
 #### 24.5 Creator Portal Resubmission
 - [ ] Submeter v1.0.0 estável no n8n Creator Portal


### PR DESCRIPTION
## Summary
- New "Output Mode" dropdown (Full / AI Summary) when Simplify is disabled
- AI Summary: 8 flat English key-value fields optimized for AI Agent `usableAsTool`
- Backward-compatible: `simplify: true/false` unchanged for existing workflows
- All living docs updated for v0.11.0

## Test plan
- [x] `simplify=true` → 6 pt-BR fields (unchanged)
- [x] `simplify=false, outputMode=full` → full object with endereco/socios
- [x] `simplify=false, outputMode=aiSummary` → 8 flat EN fields
- [x] `simplify=false` without outputMode → defaults to full
- [x] 1158 tests, build clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)