### PR TITLE
feat: add rate limit awareness (429 detection) — v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-03-17
+
+### Added
+- **Rate Limit Awareness** — HTTP 429 detection in fallback engine
+  - Detects 429 status from any provider, moves to next immediately
+  - Extracts `Retry-After` header when present (seconds → milliseconds)
+  - Adds `rate_limited: true` and `retry_after_ms` to `_meta` output
+  - Specific error message when all providers are rate-limited: "All providers rate-limited or failed"
+  - Works across all 9 resources via shared `queryWithFallback`
+- 9 new rate limit tests (429 detection, Retry-After parsing, error messages, edge cases)
+
+### Changed
+- `IFallbackResult` now includes `rateLimited` and `retryAfterMs` fields
+- `IMeta` now includes optional `rate_limited` and `retry_after_ms` fields
+- `buildMeta` accepts optional `rateLimited` and `retryAfterMs` params
+- All 10 execute handlers pass rate limit info through to `_meta`
+- 1167 tests total (was 1158)
+
 ## [0.11.0] - 2026-03-17
 
 ### Added
@@ -341,7 +359,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration (npm + GitHub Actions weekly updates)
 - MIT license
 
-[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.9.0...v0.10.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,7 +37,7 @@ Each new resource ships as its own MINOR release for faster iteration and easier
 
 - [ ] **Configurable Provider Order** — User chooses primary provider per resource
 - [x] **Configurable Timeout** — Override default 10s timeout per operation
-- [ ] **Rate Limit Awareness** — Detect HTTP 429, retry with exponential backoff
+- [x] **Rate Limit Awareness** — Detect HTTP 429, skip to next provider, expose in _meta
 - [x] **CNPJ Output Mode** — Simplified (default), Full, AI Summary
 - [ ] **Creator Portal resubmission** — Submit stable v1.0.0 for "Verified" badge
 - [ ] Comprehensive documentation site or wiki

--- a/__tests__/fallback.spec.ts
+++ b/__tests__/fallback.spec.ts
@@ -162,6 +162,99 @@ describe('queryWithFallback', () => {
 		);
 	});
 
+	it('should set rateLimited=true when a provider returns 429', async () => {
+		const err429 = Object.assign(new Error('Too Many Requests'), { httpCode: 429 });
+		let callIndex = 0;
+		const ctx = {
+			helpers: {
+				httpRequest: jest.fn().mockImplementation(async () => {
+					callIndex++;
+					if (callIndex === 1) throw err429;
+					return { ok: true };
+				}),
+			},
+		} as unknown as Parameters<typeof queryWithFallback>[0];
+		const result = await queryWithFallback(ctx, providers);
+		expect(result.rateLimited).toBe(true);
+		expect(result.provider).toBe('provider2');
+		expect(result.errors).toEqual(['provider1: [429] Too Many Requests']);
+	});
+
+	it('should extract Retry-After header from 429 response', async () => {
+		const err429 = Object.assign(new Error('Too Many Requests'), {
+			httpCode: 429,
+			headers: { 'retry-after': '3' },
+		});
+		let callIndex = 0;
+		const ctx = {
+			helpers: {
+				httpRequest: jest.fn().mockImplementation(async () => {
+					callIndex++;
+					if (callIndex === 1) throw err429;
+					return { ok: true };
+				}),
+			},
+		} as unknown as Parameters<typeof queryWithFallback>[0];
+		const result = await queryWithFallback(ctx, providers);
+		expect(result.rateLimited).toBe(true);
+		expect(result.retryAfterMs).toBe(3000);
+	});
+
+	it('should throw rate-limit-specific error when all providers 429', async () => {
+		const make429 = () => Object.assign(new Error('Too Many Requests'), { httpCode: 429 });
+		const ctx = {
+			helpers: {
+				httpRequest: jest.fn().mockRejectedValue(make429()),
+			},
+		} as unknown as Parameters<typeof queryWithFallback>[0];
+		await expect(queryWithFallback(ctx, providers)).rejects.toThrow(
+			'All providers rate-limited or failed',
+		);
+	});
+
+	it('should set rateLimited=false when no 429 occurs', async () => {
+		const ctx = createMockContext([{ success: true, data: { ok: true } }]);
+		const result = await queryWithFallback(ctx, providers);
+		expect(result.rateLimited).toBe(false);
+		expect(result.retryAfterMs).toBeUndefined();
+	});
+
+	it('should handle 429 as string httpCode', async () => {
+		const err429 = Object.assign(new Error('Rate limited'), { httpCode: '429' });
+		let callIndex = 0;
+		const ctx = {
+			helpers: {
+				httpRequest: jest.fn().mockImplementation(async () => {
+					callIndex++;
+					if (callIndex === 1) throw err429;
+					return { ok: true };
+				}),
+			},
+		} as unknown as Parameters<typeof queryWithFallback>[0];
+		const result = await queryWithFallback(ctx, providers);
+		expect(result.rateLimited).toBe(true);
+	});
+
+	it('should ignore invalid Retry-After values', async () => {
+		const err429 = Object.assign(new Error('Rate limited'), {
+			httpCode: 429,
+			headers: { 'retry-after': 'invalid' },
+		});
+		let callIndex = 0;
+		const ctx = {
+			helpers: {
+				httpRequest: jest.fn().mockImplementation(async () => {
+					callIndex++;
+					if (callIndex === 1) throw err429;
+					return { ok: true };
+				}),
+			},
+		} as unknown as Parameters<typeof queryWithFallback>[0];
+		const result = await queryWithFallback(ctx, providers);
+		expect(result.rateLimited).toBe(true);
+		expect(result.retryAfterMs).toBeUndefined();
+	});
+
 	it('should collect all error messages from failed providers', async () => {
 		const ctx = createMockContext([
 			{ success: false, error: 'Timeout' },
@@ -233,5 +326,23 @@ describe('buildMeta', () => {
 	it('should not include errors key when errors array is empty', () => {
 		const meta = buildMeta('brasilapi', 'test', []);
 		expect(Object.keys(meta)).not.toContain('errors');
+	});
+
+	it('should include rate_limited when rateLimited=true', () => {
+		const meta = buildMeta('cnpjws', '11222333000181', ['brasilapi: [429] Too Many Requests'], true, 3000);
+		expect(meta.rate_limited).toBe(true);
+		expect(meta.retry_after_ms).toBe(3000);
+	});
+
+	it('should not include rate_limited when rateLimited=false', () => {
+		const meta = buildMeta('brasilapi', 'test', []);
+		expect(Object.keys(meta)).not.toContain('rate_limited');
+		expect(Object.keys(meta)).not.toContain('retry_after_ms');
+	});
+
+	it('should include rate_limited without retry_after_ms when no Retry-After', () => {
+		const meta = buildMeta('cnpjws', 'test', ['brasilapi: [429]'], true);
+		expect(meta.rate_limited).toBe(true);
+		expect(Object.keys(meta)).not.toContain('retry_after_ms');
 	});
 });

--- a/nodes/BrasilHub/resources/banks/banks.execute.ts
+++ b/nodes/BrasilHub/resources/banks/banks.execute.ts
@@ -53,7 +53,7 @@ export async function banksQuery(
 
 	const normalized = normalizeBank(result.data, result.provider, bankCode);
 
-	const meta = buildMeta(result.provider, String(bankCode), result.errors);
+	const meta = buildMeta(result.provider, String(bankCode), result.errors, result.rateLimited, result.retryAfterMs);
 
 	return buildResultItem(normalized as unknown as Record<string, unknown>, meta, result.data, includeRaw, itemIndex) as INodeExecutionData[];
 }
@@ -80,7 +80,7 @@ export async function banksList(
 	const rawItems = result.data as Array<Record<string, unknown>>;
 	const banks = normalizeBanks(result.data, result.provider);
 
-	const meta = buildMeta(result.provider, 'all', result.errors);
+	const meta = buildMeta(result.provider, 'all', result.errors, result.rateLimited, result.retryAfterMs);
 
 	return buildResultItems(banks as unknown as Array<Record<string, unknown>>, meta, rawItems, includeRaw, itemIndex) as INodeExecutionData[];
 }

--- a/nodes/BrasilHub/resources/cep/cep.execute.ts
+++ b/nodes/BrasilHub/resources/cep/cep.execute.ts
@@ -58,7 +58,7 @@ export async function cepQuery(
 	const result = await queryWithFallback(context, providers, timeoutMs);
 
 	const normalized = normalizeCep(result.data, result.provider);
-	const meta = buildMeta(result.provider, cep, result.errors);
+	const meta = buildMeta(result.provider, cep, result.errors, result.rateLimited, result.retryAfterMs);
 
 	return buildResultItem(normalized as unknown as Record<string, unknown>, meta, result.data, includeRaw, itemIndex) as INodeExecutionData[];
 }

--- a/nodes/BrasilHub/resources/cnpj/cnpj.execute.ts
+++ b/nodes/BrasilHub/resources/cnpj/cnpj.execute.ts
@@ -55,7 +55,7 @@ export async function cnpjQuery(
 	const result = await queryWithFallback(context, providers, timeoutMs);
 
 	const full = normalizeCnpj(result.data, result.provider);
-	const meta = buildMeta(result.provider, cnpj, result.errors);
+	const meta = buildMeta(result.provider, cnpj, result.errors, result.rateLimited, result.retryAfterMs);
 	const outputMode = simplify ? 'simplified' : (context.getNodeParameter('outputMode', itemIndex, 'full') as string);
 
 	let normalized: Record<string, unknown>;

--- a/nodes/BrasilHub/resources/ddd/ddd.execute.ts
+++ b/nodes/BrasilHub/resources/ddd/ddd.execute.ts
@@ -41,7 +41,7 @@ export async function dddQuery(
 	const result = await queryWithFallback(context, providers, timeoutMs);
 	const normalized = normalizeDdd(result.data, result.provider, ddd);
 
-	const meta = buildMeta(result.provider, String(ddd), result.errors);
+	const meta = buildMeta(result.provider, String(ddd), result.errors, result.rateLimited, result.retryAfterMs);
 
 	return buildResultItem(normalized as unknown as Record<string, unknown>, meta, result.data, includeRaw, itemIndex) as INodeExecutionData[];
 }

--- a/nodes/BrasilHub/resources/feriados/feriados.execute.ts
+++ b/nodes/BrasilHub/resources/feriados/feriados.execute.ts
@@ -51,7 +51,7 @@ export async function feriadosQuery(
 
 	const feriados = normalizeFeriados(result.data, result.provider);
 	const rawItems = Array.isArray(result.data) ? result.data as Array<Record<string, unknown>> : [];
-	const meta = buildMeta(result.provider, String(year), result.errors);
+	const meta = buildMeta(result.provider, String(year), result.errors, result.rateLimited, result.retryAfterMs);
 
 	return buildResultItems(feriados as unknown as Array<Record<string, unknown>>, meta, rawItems, includeRaw, itemIndex) as INodeExecutionData[];
 }

--- a/nodes/BrasilHub/resources/ibge/ibge.execute.ts
+++ b/nodes/BrasilHub/resources/ibge/ibge.execute.ts
@@ -47,7 +47,7 @@ export async function ibgeStates(
 	const result = await queryWithFallback(context, STATES_PROVIDERS, timeoutMs);
 	const states = normalizeStates(result.data, result.provider);
 	const rawItems = Array.isArray(result.data) ? result.data as Array<Record<string, unknown>> : [];
-	const meta = buildMeta(result.provider, 'all', result.errors);
+	const meta = buildMeta(result.provider, 'all', result.errors, result.rateLimited, result.retryAfterMs);
 
 	return buildResultItems(states as unknown as Array<Record<string, unknown>>, meta, rawItems, includeRaw, itemIndex) as INodeExecutionData[];
 }
@@ -80,7 +80,7 @@ export async function ibgeCities(
 	const result = await queryWithFallback(context, providers, timeoutMs);
 	const cities = normalizeCities(result.data, result.provider);
 	const rawItems = Array.isArray(result.data) ? result.data as Array<Record<string, unknown>> : [];
-	const meta = buildMeta(result.provider, ufInput, result.errors);
+	const meta = buildMeta(result.provider, ufInput, result.errors, result.rateLimited, result.retryAfterMs);
 
 	return buildResultItems(cities as unknown as Array<Record<string, unknown>>, meta, rawItems, includeRaw, itemIndex) as INodeExecutionData[];
 }

--- a/nodes/BrasilHub/resources/ncm/ncm.execute.ts
+++ b/nodes/BrasilHub/resources/ncm/ncm.execute.ts
@@ -29,7 +29,7 @@ export async function ncmQuery(
 	];
 	const result = await queryWithFallback(context, providers, timeoutMs);
 	const normalized = normalizeNcm(result.data);
-	const meta = buildMeta(result.provider, ncmCode, result.errors);
+	const meta = buildMeta(result.provider, ncmCode, result.errors, result.rateLimited, result.retryAfterMs);
 
 	return buildResultItem(normalized as unknown as Record<string, unknown>, meta, result.data, includeRaw, itemIndex) as INodeExecutionData[];
 }
@@ -64,7 +64,7 @@ export async function ncmSearch(
 	const result = await queryWithFallback(context, providers, timeoutMs);
 	const items = normalizeNcmList(result.data);
 	const rawItems = Array.isArray(result.data) ? result.data as Array<Record<string, unknown>> : [];
-	const meta = buildMeta(result.provider, searchTerm, result.errors);
+	const meta = buildMeta(result.provider, searchTerm, result.errors, result.rateLimited, result.retryAfterMs);
 
 	return buildResultItems(items as unknown as Array<Record<string, unknown>>, meta, rawItems, includeRaw, itemIndex) as INodeExecutionData[];
 }

--- a/nodes/BrasilHub/shared/fallback.ts
+++ b/nodes/BrasilHub/shared/fallback.ts
@@ -36,6 +36,8 @@ export async function queryWithFallback(
 ): Promise<IFallbackResult> {
 	const safeTimeout = clampTimeout(timeoutMs);
 	const errors: string[] = [];
+	let rateLimited = false;
+	let retryAfterMs: number | undefined;
 
 	for (const provider of providers) {
 		try {
@@ -49,14 +51,28 @@ export async function queryWithFallback(
 				timeout: safeTimeout,
 			});
 
-			return { data, provider: provider.name, errors };
+			return { data, provider: provider.name, errors, rateLimited, retryAfterMs };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			const httpCode = (error as Record<string, unknown>)?.httpCode;
 			const detail = httpCode ? `[${httpCode}] ${message}` : message;
 			errors.push(`${provider.name}: ${detail}`);
+
+			if (httpCode === 429 || httpCode === '429') {
+				rateLimited = true;
+				const retryHeader = (error as Record<string, Record<string, unknown>>)?.headers?.['retry-after'];
+				if (retryHeader != null) {
+					const seconds = Number(retryHeader);
+					if (Number.isFinite(seconds) && seconds > 0) {
+						retryAfterMs = Math.round(seconds * 1000);
+					}
+				}
+			}
 		}
 	}
 
-	throw new Error(`No provider could fulfill the request: ${errors.join('; ')}`);
+	const prefix = rateLimited
+		? 'All providers rate-limited or failed'
+		: 'No provider could fulfill the request';
+	throw new Error(`${prefix}: ${errors.join('; ')}`);
 }

--- a/nodes/BrasilHub/shared/utils.ts
+++ b/nodes/BrasilHub/shared/utils.ts
@@ -24,12 +24,20 @@ export function safeStr(value: unknown): string {
  * @param errors - Error messages from providers that failed before the successful one.
  * @returns IMeta object ready to attach to the response.
  */
-export function buildMeta(provider: string, query: string, errors: string[]): {
+export function buildMeta(
+	provider: string,
+	query: string,
+	errors: string[],
+	rateLimited = false,
+	retryAfterMs?: number,
+): {
 	provider: string;
 	query: string;
 	queried_at: string;
 	strategy: 'fallback' | 'direct';
 	errors?: string[];
+	rate_limited?: boolean;
+	retry_after_ms?: number;
 } {
 	return {
 		provider,
@@ -37,6 +45,8 @@ export function buildMeta(provider: string, query: string, errors: string[]): {
 		queried_at: new Date().toISOString(),
 		strategy: errors.length > 0 ? 'fallback' : 'direct',
 		...(errors.length > 0 && { errors }),
+		...(rateLimited && { rate_limited: true }),
+		...(retryAfterMs != null && { retry_after_ms: retryAfterMs }),
 	};
 }
 

--- a/nodes/BrasilHub/types.ts
+++ b/nodes/BrasilHub/types.ts
@@ -102,6 +102,10 @@ export interface IMeta {
 	strategy: 'fallback' | 'direct';
 	/** Error messages from providers that failed before the successful one. */
 	errors?: string[];
+	/** Whether at least one provider returned HTTP 429 (rate limited). */
+	rate_limited?: boolean;
+	/** Suggested retry delay in milliseconds from the last 429 Retry-After header. */
+	retry_after_ms?: number;
 }
 
 /** Normalized bank query result, unified across providers (BrasilAPI, BancosBrasileiros). */
@@ -274,4 +278,8 @@ export interface IFallbackResult {
 	provider: string;
 	/** Error messages from providers that failed before the successful one. */
 	errors: string[];
+	/** Whether at least one provider returned HTTP 429. */
+	rateLimited: boolean;
+	/** Suggested retry delay in ms from the last 429 Retry-After header, if present. */
+	retryAfterMs?: number;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-brasil-hub",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "n8n community node for querying Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Feriados, FIPE, IBGE, NCM) with multi-provider fallback",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",

--- a/task_plan.md
+++ b/task_plan.md
@@ -410,9 +410,11 @@ Each new resource ships as its own MINOR release:
 - [x] Released as v0.10.0
 
 #### 24.3 Rate Limit Awareness
-- [ ] Detectar HTTP 429 no fallback engine
-- [ ] Retry com backoff exponencial (sem setTimeout — loop com delay via n8n helpers)
-- [ ] Respeitar header `Retry-After` se presente
+- [x] Detectar HTTP 429 no fallback engine (skip to next provider)
+- [x] Extrair `Retry-After` header → `retry_after_ms` no _meta
+- [x] Erro específico "All providers rate-limited or failed"
+- [x] 9 novos testes, released as v0.12.0
+- Note: backoff exponencial não implementado (setTimeout banned em community nodes). Fallback chain IS the backoff.
 
 #### 24.4 CNPJ Output Mode
 - [x] Param "Output Mode": Full (default), AI Summary — appears when Simplify is disabled


### PR DESCRIPTION
## Summary
- HTTP 429 detection in fallback engine — skip rate-limited provider, move to next
- Extract `Retry-After` header → `retry_after_ms` in `_meta`
- Specific error when all providers 429: "All providers rate-limited or failed"
- Works across all 9 resources via shared `queryWithFallback`
- No `setTimeout` — community node scan compatible

## Test plan
- [x] 429 on first provider → fallback to second, `rateLimited=true`
- [x] 429 with `Retry-After: 3` → `retryAfterMs=3000`
- [x] All providers 429 → specific error message
- [x] No 429 → `rateLimited=false`, no `retry_after_ms` in meta
- [x] 429 as string httpCode → detected
- [x] Invalid Retry-After → ignored gracefully
- [x] `buildMeta` with rate limit fields
- [x] 1167 tests, build clean, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)