### PR TITLE
docs: propagate Holiday rename to all living docs — v1.0.2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-n8n community node (`n8n-nodes-brasil-hub`) for querying Brazilian public data. Single "Brasil Hub" node with resource/operation routing pattern. Currently ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Feriados, FIPE, IBGE, and NCM resources (v1.0.x) — 9 resources, 17 operations, 22 providers, configurable timeout + provider order, rate limit awareness, CNPJ output mode.
+n8n community node (`n8n-nodes-brasil-hub`) for querying Brazilian public data. Single "Brasil Hub" node with resource/operation routing pattern. Currently ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Holiday (Feriados), FIPE, IBGE, and NCM resources (v1.0.x) — 9 resources, 17 operations, 22 providers, configurable timeout + provider order, rate limit awareness, CNPJ output mode.
 
 ## Tech Stack
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-03-18
+
+### Fixed
+- Propagated `Feriado` → `Holiday` rename to all living docs: README, CLAUDE.md, copilot-instructions, package.json description, node description, ROADMAP
+- Updated README hero text and Roadmap link description
+
 ## [1.0.1] - 2026-03-18
 
 ### Fixed
@@ -401,7 +407,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration (npm + GitHub Actions weekly updates)
 - MIT license
 
-[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.13.0...v1.0.0
 [0.13.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.12.0...v0.13.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Community n8n node (`n8n-nodes-brasil-hub`) that centralizes Brazilian public data queries. A single "Brasil Hub" node with extensible resources — v1.0.x ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Feriados, FIPE, IBGE, and NCM — 9 resources, 17 operations, 22 providers, configurable timeout, configurable provider order, rate limit awareness, CNPJ output mode.
+Community n8n node (`n8n-nodes-brasil-hub`) that centralizes Brazilian public data queries. A single "Brasil Hub" node with extensible resources — v1.0.x ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Holiday (Feriados), FIPE, IBGE, and NCM — 9 resources, 17 operations, 22 providers, configurable timeout, configurable provider order, rate limit awareness, CNPJ output mode.
 
 - **License:** MIT
 - **Tech Stack:** TypeScript, n8n-workflow, Jest + ts-jest
@@ -105,7 +105,7 @@ Zero changes to existing resource files — only the router registration.
 **CEP:** BrasilAPI → ViaCEP → OpenCEP → ApiCEP
 **Banks:** BrasilAPI → BancosBrasileiros
 **DDD:** BrasilAPI → municipios-brasileiros
-**Feriados:** BrasilAPI → Nager.Date
+**Holiday (Feriados):** BrasilAPI → Nager.Date
 **FIPE:** parallelum (single provider — hierarchy API)
 
 Fallback is automatic. BrasilAPI is always primary. Headers include `User-Agent: n8n-brasil-hub-node/1.0`. Timeout is configurable per-node (default 10s, range 1–60s).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Brasil Hub for n8n</h1>
 
 <p align="center">
-  Query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Feriados, FIPE, IBGE &amp; NCM) with automatic multi-provider fallback — zero configuration, zero credentials.
+  Query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE &amp; NCM) with automatic multi-provider fallback — zero configuration, zero credentials.
 </p>
 
 <p align="center">
@@ -52,7 +52,7 @@ npm install n8n-nodes-brasil-hub
 | **CNPJ** | Validate | Check if CNPJ is valid (local checksum, no API) | — |
 | **CPF** | Validate | Check if CPF is valid (local checksum, no API) | — |
 | **DDD** | Query | Fetch state and cities by area code | BrasilAPI → municipios-brasileiros |
-| **Feriado** | Query | Fetch public holidays by year | BrasilAPI → Nager.Date |
+| **Holiday** | Query | Fetch public holidays by year | BrasilAPI → Nager.Date |
 | **FIPE** | Brands | List vehicle brands by type | parallelum |
 | **FIPE** | Models | List models for a brand | parallelum |
 | **FIPE** | Years | List available years for a model | parallelum |
@@ -175,7 +175,7 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for full development guidelines.
 
 | | |
 |---|---|
-| [Roadmap](ROADMAP.md) | Planned features (Feriados, more providers) |
+| [Roadmap](ROADMAP.md) | Planned features and version history |
 | [Changelog](CHANGELOG.md) | Version history |
 | [Contributing](.github/CONTRIBUTING.md) | How to contribute |
 | [Security](.github/SECURITY.md) | Vulnerability reporting |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,14 +4,14 @@ This document describes the planned direction for n8n-nodes-brasil-hub.
 
 Each new resource ships as its own MINOR release for faster iteration and easier rollback.
 
-## Current (v0.7.x) ✅
+## v0.1–v0.7 — Foundation ✅
 
 - [x] **CNPJ resource** (Query + Validate) with 7 providers ([#36](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/36))
 - [x] **CEP resource** (Query + Validate) with 4 providers ([#37](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/37))
 - [x] **CPF resource** (Validate) — local checksum ([#5](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/5))
 - [x] **Bank resource** (Query + List) with 2 providers ([#32](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/32))
 - [x] **DDD resource** (Query) with 2 providers ([#33](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/33))
-- [x] **Feriado resource** (Query) with 2 providers ([#35](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/35))
+- [x] **Holiday resource** (Query) with 2 providers ([#35](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/35))
 - [x] **FIPE resource** (Brands, Models, Years, Price) with 1 provider ([#34](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/34))
 - [x] CNPJ Simplify parameter ([#38](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/38))
 - [x] Enhanced error messages with HTTP status ([#39](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/39))

--- a/nodes/BrasilHub/BrasilHub.node.ts
+++ b/nodes/BrasilHub/BrasilHub.node.ts
@@ -85,7 +85,7 @@ export class BrasilHub implements INodeType {
 		group: [],
 		version: 1,
 		subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
-		description: 'Query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Feriados, FIPE, IBGE, NCM) with multi-provider fallback',
+		description: 'Query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM) with multi-provider fallback',
 		defaults: {
 			name: 'Brasil Hub',
 		},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-brasil-hub",
-  "version": "1.0.1",
-  "description": "n8n community node for querying Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Feriados, FIPE, IBGE, NCM) with multi-provider fallback",
+  "version": "1.0.2",
+  "description": "n8n community node for querying Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM) with multi-provider fallback",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",
   "keywords": [


### PR DESCRIPTION
## Summary
Propagated `Feriado` → `Holiday` rename missed in v1.0.1:
- README hero text + operations table + roadmap link
- package.json description
- Node description string
- CLAUDE.md + copilot-instructions.md
- ROADMAP.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)