### PR TITLE
fix: FIPE buildMeta consistency + fallback JSDoc — v1.0.2

### DIFF
--- a/nodes/BrasilHub/resources/fipe/fipe.execute.ts
+++ b/nodes/BrasilHub/resources/fipe/fipe.execute.ts
@@ -82,7 +82,7 @@ export async function fipeBrands(
 
 	const brands = normalizeBrands(data);
 	const rawItems = Array.isArray(data) ? data as Array<Record<string, unknown>> : [];
-	const meta = buildMeta('parallelum', vehicleType, []);
+	const meta = buildMeta('parallelum', vehicleType, [], false);
 
 	return buildResultItems(brands as unknown as Array<Record<string, unknown>>, meta, rawItems, includeRaw, itemIndex) as INodeExecutionData[];
 }
@@ -111,7 +111,7 @@ export async function fipeModels(
 
 	const models = normalizeModels(data);
 	const rawModelos = ((data as Record<string, unknown>)?.modelos ?? []) as Array<Record<string, unknown>>;
-	const meta = buildMeta('parallelum', `${vehicleType}/${brandCode}`, []);
+	const meta = buildMeta('parallelum', `${vehicleType}/${brandCode}`, [], false);
 
 	return buildResultItems(models as unknown as Array<Record<string, unknown>>, meta, rawModelos, includeRaw, itemIndex) as INodeExecutionData[];
 }
@@ -142,7 +142,7 @@ export async function fipeYears(
 
 	const years = normalizeYears(data);
 	const rawItems = Array.isArray(data) ? data as Array<Record<string, unknown>> : [];
-	const meta = buildMeta('parallelum', `${vehicleType}/${brandCode}/${modelCode}`, []);
+	const meta = buildMeta('parallelum', `${vehicleType}/${brandCode}/${modelCode}`, [], false);
 
 	return buildResultItems(years as unknown as Array<Record<string, unknown>>, meta, rawItems, includeRaw, itemIndex) as INodeExecutionData[];
 }
@@ -174,7 +174,7 @@ export async function fipePrice(
 	const data = await fetchFipe(context, url, timeoutMs);
 
 	const price = normalizePrice(data);
-	const meta = buildMeta('parallelum', `${vehicleType}/${brandCode}/${modelCode}/${yearCode}`, []);
+	const meta = buildMeta('parallelum', `${vehicleType}/${brandCode}/${modelCode}/${yearCode}`, [], false);
 
 	return buildResultItem(price as unknown as Record<string, unknown>, meta, data, includeRaw, itemIndex) as INodeExecutionData[];
 }

--- a/nodes/BrasilHub/shared/fallback.ts
+++ b/nodes/BrasilHub/shared/fallback.ts
@@ -27,7 +27,7 @@ export function clampTimeout(value: number): number {
  * @param providers - Ordered list of provider endpoints to try.
  * @param timeoutMs - HTTP timeout in milliseconds (default: {@link DEFAULT_TIMEOUT_MS}).
  * @returns Raw response data from the first successful provider.
- * @throws {Error} When all providers fail, with concatenated error messages.
+ * @throws {Error} When all providers fail, with concatenated error messages. Wrapped by the router as NodeOperationError with itemIndex.
  */
 export async function queryWithFallback(
 	context: IExecuteFunctions,


### PR DESCRIPTION
## Summary
- FIPE buildMeta: explicit `false` for rateLimited (consistency with 10 other handlers)
- fallback.ts JSDoc: documented why Error (not NodeApiError) is correct for aggregated multi-provider errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)