### PR TITLE
chore: bump to v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-03-18
+
+### Fixed
+- FIPE buildMeta calls now pass explicit `false` for rateLimited (consistency with 10 other handlers)
+- Documented in JSDoc why fallback.ts uses Error (not NodeApiError) for aggregated multi-provider errors
+
 ## [1.0.2] - 2026-03-18
 
 ### Fixed
@@ -407,7 +413,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration (npm + GitHub Actions weekly updates)
 - MIT license
 
-[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v0.13.0...v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-brasil-hub",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "n8n community node for querying Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM) with multi-provider fallback",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",


### PR DESCRIPTION
Version bump for FIPE buildMeta fix published after v1.0.2 tag.