### PR TITLE
chore: bump v1.1.1 — npm README update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-03-19
+
+### Changed
+- README: prominent downloads + stars badges (for-the-badge style)
+- GitHub: 17 repository topics added for discoverability
+
 ## [1.1.0] - 2026-03-19
 
 ### Added
@@ -431,7 +437,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration (npm + GitHub Actions weekly updates)
 - MIT license
 
-[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.1...v1.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-brasil-hub",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "n8n community node to query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM) — 22 providers with automatic fallback, no credentials required, AI Agent ready",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",


### PR DESCRIPTION
Publishes updated README with prominent download/stars badges to npm.