### PR TITLE
fix(ci): configure Release Please to use simple v-tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",
+      "component": "n8n-nodes-brasil-hub",
       "changelog-sections": [
         { "type": "feat", "section": "Added" },
         { "type": "fix", "section": "Fixed" },


### PR DESCRIPTION
## Summary

- Release Please was looking for tags like `n8n-nodes-brasil-hub-v1.1.1` but existing tags are `v1.1.1`
- Added `include-component-in-tag: false` to `release-please-config.json`
- Added explicit `component` field for internal tracking

## Root cause

Release Please defaults to using the package name as a tag prefix (monorepo pattern). Single-package repos need `include-component-in-tag: false`.

## Test plan

- [ ] Release Please workflow passes after merge
- [ ] No "Found release tag with component" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)