### PR TITLE
docs: update living docs for v1.2.0

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
+| 1.2.x   | :white_check_mark: |
+| 1.0.x–1.1.x | :white_check_mark: |
 | < 1.0   | :x:                |
 
 ## Reporting a Vulnerability

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-n8n community node (`n8n-nodes-brasil-hub`) for querying Brazilian public data. Single "Brasil Hub" node with resource/operation routing pattern. Currently ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Holiday (Feriados), FIPE, IBGE, and NCM resources (v1.0.x) — 9 resources, 17 operations, 22 providers, configurable timeout + provider order, rate limit awareness, CNPJ output mode.
+n8n community node (`n8n-nodes-brasil-hub`) for querying Brazilian public data. Single "Brasil Hub" node with resource/operation routing pattern. Currently ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Holiday (Feriados), FIPE, IBGE, NCM, and PIX resources (v1.2.x) — 10 resources, 20 operations, 23 providers, configurable timeout + provider order, rate limit awareness, CNPJ output mode.
 
 ## Tech Stack
 
@@ -23,7 +23,7 @@ nodes/BrasilHub/
 ├── shared/validators.ts         # CNPJ/CPF checksum, CEP format (local, no API)
 ├── shared/fallback.ts           # Generic multi-provider fallback
 ├── shared/utils.ts              # Shared utilities (stripNonDigits, safeStr)
-└── resources/{cnpj,cep,cpf,banks,ddd,feriados,fipe,ibge,ncm}/  # description, execute, normalize per resource
+└── resources/{cnpj,cep,cpf,banks,ddd,feriados,fipe,ibge,ncm,pix}/  # description, execute, normalize per resource
 ```
 
 ## n8n Node Conventions (MUST follow)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Brasil Hub for n8n</h1>
 
 <p align="center">
-  Query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE &amp; NCM) with automatic multi-provider fallback — zero configuration, zero credentials.
+  Query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM &amp; PIX) with automatic multi-provider fallback — zero configuration, zero credentials.
 </p>
 
 <p align="center">
@@ -23,7 +23,7 @@
 
 ---
 
-> **Stable Release (v1.0)** — 9 resources, 17 operations, 22 providers. The API is stable and follows semantic versioning.
+> **v1.2** — 10 resources, 20 operations, 23 providers. The API is stable and follows semantic versioning.
 
 ---
 
@@ -61,12 +61,15 @@ npm install n8n-nodes-brasil-hub
 | **Holiday** | Query | Fetch public holidays by year | BrasilAPI → Nager.Date |
 | **FIPE** | Brands | List vehicle brands by type | parallelum |
 | **FIPE** | Models | List models for a brand | parallelum |
-| **FIPE** | Years | List available years for a model | parallelum |
 | **FIPE** | Price | Get FIPE table price for a vehicle | parallelum |
+| **FIPE** | Reference Tables | List available FIPE reference tables | parallelum |
+| **FIPE** | Years | List available years for a model | parallelum |
 | **IBGE** | States | List all Brazilian states | BrasilAPI → IBGE API |
 | **IBGE** | Cities | List municipalities by state | BrasilAPI → IBGE API |
 | **NCM** | Query | Fetch tax classification by code | BrasilAPI |
 | **NCM** | Search | Search tax codes by description | BrasilAPI |
+| **PIX** | List | List all PIX participants | BrasilAPI |
+| **PIX** | Query | Look up PIX participant by ISPB code | BrasilAPI |
 
 ## Example Output
 
@@ -162,7 +165,7 @@ Each provider has a **configurable timeout** (default: 10 seconds, range: 1–60
 git clone https://github.com/luisbarcia/n8n-nodes-brasil-hub.git
 cd n8n-nodes-brasil-hub
 npm install
-npm test          # 1174 tests, 99%+ coverage
+npm test          # 1280 tests, 99%+ coverage
 npm run build
 npm run lint
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,12 +41,17 @@ Each new resource ships as its own MINOR release for faster iteration and easier
 - [x] **CNPJ Output Mode** — Simplified (default), Full, AI Summary
 - [ ] **Creator Portal resubmission** — Submit stable v1.0.0 for "Verified" badge
 
-## v1.1.0+ — Expansion (ideas, not committed)
+## v1.2.0 — FIPE Reference Tables + PIX ✅
 
-- [ ] **PIX Directory** — Query PIX participants (BCB API)
-- [ ] **CNES** — Health establishments (DataSUS)
-- [ ] **Historical FIPE** — Query past reference tables
-- [ ] **Correios Tracking** — Package tracking (if public API available)
+- [x] **FIPE Reference Tables** — List available FIPE reference tables with optional year filter ([#109](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/109))
+- [x] **PIX Directory** — Query PIX participants from BCB directory (BrasilAPI) ([#110](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/110))
+- [x] Operations: `referenceTables` (FIPE), `list` + `query` (PIX)
+- [x] 1280 tests, testing arsenal audit passed
+
+## Future — Expansion (ideas, not committed)
+
+- [ ] **CNES** — Health establishments (DataSUS) — APIs currently unavailable ([#111](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/111))
+- [ ] **Correios Tracking** — Package tracking — no public credential-free API found ([#112](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/112))
 
 ## Not Planned
 

--- a/nodes/BrasilHub/BrasilHub.node.json
+++ b/nodes/BrasilHub/BrasilHub.node.json
@@ -6,7 +6,7 @@
 	"subcategories": {
 		"Data & Storage": ["Request Making"]
 	},
-	"alias": ["brazil", "brasil", "brazilian", "cnpj", "cpf", "cep", "banks", "banco", "ddd", "feriados", "holidays", "fipe", "vehicle", "ibge", "states", "cities", "municipios", "ncm", "tax-classification", "area-code", "tax-id", "zip-code", "postal-code", "address", "endereco", "company", "empresa", "consulta", "receita", "validation", "public-data", "tabela-fipe"],
+	"alias": ["brazil", "brasil", "brazilian", "cnpj", "cpf", "cep", "banks", "banco", "ddd", "feriados", "holidays", "fipe", "vehicle", "ibge", "states", "cities", "municipios", "ncm", "tax-classification", "area-code", "tax-id", "zip-code", "postal-code", "address", "endereco", "company", "empresa", "consulta", "receita", "validation", "public-data", "tabela-fipe", "pix", "instant-payment", "ispb", "banco-central", "pagamento"],
 	"resources": {
 		"primaryDocumentation": [
 			{

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-brasil-hub",
   "version": "1.1.1",
-  "description": "n8n community node to query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM) — 22 providers with automatic fallback, no credentials required, AI Agent ready",
+  "description": "n8n community node to query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM, PIX) — 23 providers with automatic fallback, no credentials required, AI Agent ready",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",
   "keywords": [
@@ -35,7 +35,11 @@
     "company",
     "tax-id",
     "validation",
-    "api-fallback"
+    "api-fallback",
+    "pix",
+    "instant-payment",
+    "bcb",
+    "central-bank"
   ],
   "author": {
     "name": "Luis Barcia",


### PR DESCRIPTION
## Summary

Update all living docs to reflect v1.2.0 features (FIPE Reference Tables + PIX resource).

- **README**: PIX + FIPE Reference Tables in operations table, 10 resources / 20 ops / 23 providers / 1280 tests
- **ROADMAP**: v1.2.0 section marked done, future section restructured
- **package.json**: PIX in description, +4 keywords
- **SECURITY.md**: 1.2.x added to supported versions
- **copilot-instructions**: updated counts and directory listing
- **Codex**: +5 aliases for PIX discoverability

## Test plan

- [ ] No code changes — docs only
- [ ] CI passes (lint, build, tests unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)