### PR TITLE
fix: testing arsenal findings on architecture refactoring

### DIFF
--- a/__tests__/BrasilHub.node.spec.ts
+++ b/__tests__/BrasilHub.node.spec.ts
@@ -28,6 +28,32 @@ describe('BrasilHub node', () => {
 		expect(values).toContain('fake');
 	});
 
+	it('should have no duplicate resource keys in allResources', () => {
+		const node = new BrasilHub();
+		const resourceProp = node.description.properties.find((p) => p.name === 'resource');
+		const uiValues = (resourceProp!.options as Array<{ value: string }>).map((o) => o.value);
+		const uniqueValues = new Set(uiValues);
+		expect(uniqueValues.size).toBe(uiValues.length);
+	});
+
+	it('should have matching resource keys between UI options and operation descriptions', () => {
+		const node = new BrasilHub();
+		const resourceProp = node.description.properties.find((p) => p.name === 'resource');
+		const uiValues = new Set((resourceProp!.options as Array<{ value: string }>).map((o) => o.value));
+		const opProps = node.description.properties.filter((p) => p.name === 'operation');
+		const opResources = new Set(
+			opProps.map((p) => (p.displayOptions?.show?.resource as string[])?.[0]).filter(Boolean),
+		);
+		// Every UI resource must have an operation description
+		for (const uiVal of uiValues) {
+			expect(opResources.has(uiVal)).toBe(true);
+		}
+		// Every operation description must have a UI resource
+		for (const opRes of opResources) {
+			expect(uiValues.has(opRes)).toBe(true);
+		}
+	});
+
 	it('should have operation properties for all resources', () => {
 		const node = new BrasilHub();
 		const ops = node.description.properties.filter((p) => p.name === 'operation');

--- a/__tests__/utils.spec.ts
+++ b/__tests__/utils.spec.ts
@@ -1,4 +1,5 @@
 import { readCommonParams } from '../nodes/BrasilHub/shared/utils';
+import { includeRawField } from '../nodes/BrasilHub/shared/description-builders';
 
 function createMockContext(overrides: Record<string, unknown> = {}) {
 	const params: Record<string, unknown> = {
@@ -41,5 +42,31 @@ describe('readCommonParams', () => {
 		expect(ctx.getNodeParameter).toHaveBeenCalledWith('includeRaw', 5, false);
 		expect(ctx.getNodeParameter).toHaveBeenCalledWith('timeout', 5, 10000);
 		expect(ctx.getNodeParameter).toHaveBeenCalledWith('primaryProvider', 5, 'auto');
+	});
+});
+
+describe('includeRawField', () => {
+	it('should generate field for all operations when no filter', () => {
+		const field = includeRawField('banks');
+		expect(field.displayName).toBe('Include Raw Response');
+		expect(field.name).toBe('includeRaw');
+		expect(field.type).toBe('boolean');
+		expect(field.default).toBe(false);
+		expect(field.displayOptions?.show).toEqual({ resource: ['banks'] });
+	});
+
+	it('should generate field with operation filter', () => {
+		const field = includeRawField('cnpj', ['query']);
+		expect(field.displayOptions?.show).toEqual({ resource: ['cnpj'], operation: ['query'] });
+	});
+
+	it('should generate field with multiple operation filter', () => {
+		const field = includeRawField('cep', ['query', 'validate']);
+		expect(field.displayOptions?.show).toEqual({ resource: ['cep'], operation: ['query', 'validate'] });
+	});
+
+	it('should have "Whether" prefix in description', () => {
+		const field = includeRawField('ddd');
+		expect(field.description).toMatch(/^Whether/);
 	});
 });

--- a/nodes/BrasilHub/resources/fipe/fipe.execute.ts
+++ b/nodes/BrasilHub/resources/fipe/fipe.execute.ts
@@ -1,6 +1,6 @@
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { buildMeta, buildResultItem, buildResultItems } from '../../shared/utils';
+import { buildMeta, buildResultItem, buildResultItems, readCommonParams } from '../../shared/utils';
 import { clampTimeout, DEFAULT_TIMEOUT_MS } from '../../shared/fallback';
 import { normalizeBrands, normalizeModels, normalizeYears, normalizePrice, normalizeReferenceTables } from './fipe.normalize';
 
@@ -41,12 +41,11 @@ function validateCode(context: IExecuteFunctions, value: string, name: string, p
 	}
 }
 
-/** Reads common FIPE params from the execution context with validation. */
-function getCommonParams(context: IExecuteFunctions, itemIndex: number) {
+/** Reads common FIPE params (extends readCommonParams with vehicleType + referenceTable). */
+function getFipeParams(context: IExecuteFunctions, itemIndex: number) {
+	const { includeRaw, timeoutMs } = readCommonParams(context, itemIndex);
 	const vehicleType = context.getNodeParameter('vehicleType', itemIndex) as string;
 	const referenceTable = context.getNodeParameter('referenceTable', itemIndex, 0) as number;
-	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
 	validateVehicleType(context, vehicleType, itemIndex);
 	return { vehicleType, referenceTable, includeRaw, timeoutMs };
 }
@@ -75,8 +74,7 @@ export async function fipeReferenceTables(
 	context: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
-	const includeRaw = context.getNodeParameter('includeRaw', itemIndex, false) as boolean;
-	const timeoutMs = context.getNodeParameter('timeout', itemIndex, DEFAULT_TIMEOUT_MS) as number;
+	const { includeRaw, timeoutMs } = readCommonParams(context, itemIndex);
 	const rawFilterYear = context.getNodeParameter('filterYear', itemIndex, 0) as number;
 	const filterYear = Number.isFinite(rawFilterYear) ? Math.floor(rawFilterYear) : 0;
 
@@ -105,7 +103,7 @@ export async function fipeBrands(
 	context: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
-	const { vehicleType, referenceTable, includeRaw, timeoutMs } = getCommonParams(context, itemIndex);
+	const { vehicleType, referenceTable, includeRaw, timeoutMs } = getFipeParams(context, itemIndex);
 
 	const url = appendRefTable(`${BASE_URL}/${encodeURIComponent(vehicleType)}/marcas`, referenceTable);
 	const data = await fetchFipe(context, url, timeoutMs);
@@ -129,7 +127,7 @@ export async function fipeModels(
 	context: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
-	const { vehicleType, referenceTable, includeRaw, timeoutMs } = getCommonParams(context, itemIndex);
+	const { vehicleType, referenceTable, includeRaw, timeoutMs } = getFipeParams(context, itemIndex);
 	const brandCode = context.getNodeParameter('brandCode', itemIndex) as string;
 	validateCode(context, brandCode, 'Brand code', BRAND_MODEL_PATTERN, itemIndex);
 
@@ -158,7 +156,7 @@ export async function fipeYears(
 	context: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
-	const { vehicleType, referenceTable, includeRaw, timeoutMs } = getCommonParams(context, itemIndex);
+	const { vehicleType, referenceTable, includeRaw, timeoutMs } = getFipeParams(context, itemIndex);
 	const brandCode = context.getNodeParameter('brandCode', itemIndex) as string;
 	const modelCode = context.getNodeParameter('modelCode', itemIndex) as string;
 	validateCode(context, brandCode, 'Brand code', BRAND_MODEL_PATTERN, itemIndex);
@@ -189,7 +187,7 @@ export async function fipePrice(
 	context: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
-	const { vehicleType, referenceTable, includeRaw, timeoutMs } = getCommonParams(context, itemIndex);
+	const { vehicleType, referenceTable, includeRaw, timeoutMs } = getFipeParams(context, itemIndex);
 	const brandCode = context.getNodeParameter('brandCode', itemIndex) as string;
 	const modelCode = context.getNodeParameter('modelCode', itemIndex) as string;
 	const yearCode = context.getNodeParameter('yearCode', itemIndex) as string;


### PR DESCRIPTION
## Summary

Addresses 3 HIGH findings from test-skeptic audit of refactoring #128:

1. **Duplicate key guard**: test that allResources has no duplicate keys + UI↔router consistency
2. **FIPE readCommonParams**: getFipeParams now wraps readCommonParams (was bypassing it)
3. **includeRawField tests**: 4 tests for the description builder

Finding #1 (_raw index misalignment) tracked in #131 — pre-existing, not from refactoring.

## Stats
- 1358 tests passing (+6)
- TypeScript compiles, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)