### PR TITLE
docs: update living docs for v1.4.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,11 +58,19 @@ nodes/BrasilHub/
 │   ├── fallback.ts             # Multi-provider fallback logic
 │   └── utils.ts                # Shared utilities (stripNonDigits, safeStr, buildMeta)
 └── resources/
-    ├── banks/                  # Bank resource (description, execute, normalize)
-    ├── cep/                    # CEP resource (description, execute, normalize)
-    ├── cnpj/                   # CNPJ resource (description, execute, normalize)
-    ├── cpf/                    # CPF resource (description, execute, normalize)
-    └── ddd/                    # DDD resource (description, execute, normalize)
+    ├── banks/                  # Bank resource (Query + List)
+    ├── cambio/                 # Câmbio resource (List Currencies + Query Rate)
+    ├── cep/                    # CEP resource (Query + Validate)
+    ├── cnpj/                   # CNPJ resource (Query + Validate)
+    ├── cpf/                    # CPF resource (Validate only)
+    ├── ddd/                    # DDD resource (Query)
+    ├── fake/                   # Fake resource (Person, Company, CPF, CNPJ)
+    ├── feriados/               # Holiday resource (Query)
+    ├── fipe/                   # FIPE resource (Brands, Models, Years, Price, Ref Tables)
+    ├── ibge/                   # IBGE resource (States + Cities)
+    ├── ncm/                    # NCM resource (Query + Search)
+    ├── pix/                    # PIX resource (List + Query)
+    └── taxas/                  # Taxas resource (List + Query)
 ```
 
 ## Adding a New Resource

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.3.x   | :white_check_mark: |
-| 1.0.x–1.2.x | :white_check_mark: |
+| 1.4.x   | :white_check_mark: |
+| 1.0.x–1.3.x | :white_check_mark: |
 | < 1.0   | :x:                |
 
 ## Reporting a Vulnerability
@@ -43,7 +43,7 @@ Instead, please use one of these methods:
 
 This package:
 - Has **zero runtime dependencies** (only `n8n-workflow` as peer dependency)
-- Makes HTTP requests only to **public Brazilian data APIs** (BrasilAPI, ViaCEP, OpenCEP, ApiCEP, ReceitaWS, CNPJ.ws, MinhaReceita, OpenCNPJ.org, OpenCNPJ.com, CNPJA, BancosBrasileiros, Nager.Date, parallelum, IBGE API)
+- Makes HTTP requests only to **public Brazilian data APIs** (BrasilAPI, ViaCEP, OpenCEP, ApiCEP, ReceitaWS, CNPJ.ws, MinhaReceita, OpenCNPJ.org, OpenCNPJ.com, CNPJA, BancosBrasileiros, Nager.Date, parallelum, IBGE API, BCB/Câmbio, BCB/Taxas)
 - Does **not** store or cache any data
 - Does **not** require authentication credentials
 - Runs within the n8n sandbox with standard node permissions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-n8n community node (`n8n-nodes-brasil-hub`) for querying Brazilian public data. Single "Brasil Hub" node with resource/operation routing pattern. Currently ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Fake, Holiday (Feriados), FIPE, IBGE, NCM, and PIX resources (v1.3.x) — 11 resources, 24 operations, 23 providers + local fake data generation, configurable timeout + provider order, rate limit awareness, CNPJ output mode.
+n8n community node (`n8n-nodes-brasil-hub`) for querying Brazilian public data. Single "Brasil Hub" node with resource/operation routing pattern. Currently ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Fake, Holiday (Feriados), FIPE, IBGE, NCM, PIX, Câmbio, and Taxas resources (v1.4.x) — 13 resources, 28 operations, 25 providers + local fake data generation, configurable timeout + provider order, rate limit awareness, CNPJ output mode.
 
 ## Tech Stack
 
@@ -23,7 +23,7 @@ nodes/BrasilHub/
 ├── shared/validators.ts         # CNPJ/CPF checksum, CEP format (local, no API)
 ├── shared/fallback.ts           # Generic multi-provider fallback
 ├── shared/utils.ts              # Shared utilities (stripNonDigits, safeStr)
-└── resources/{cnpj,cep,cpf,banks,ddd,fake,feriados,fipe,ibge,ncm,pix}/  # description, execute, normalize per resource
+└── resources/{banks,cambio,cep,cnpj,cpf,ddd,fake,feriados,fipe,ibge,ncm,pix,taxas}/  # description, execute, normalize per resource
 ```
 
 ## n8n Node Conventions (MUST follow)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,8 +143,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * update living docs for v1.2.0 (10 resources, PIX + FIPE ref tables) ([#114](https://github.com/luisbarcia/n8n-nodes-brasil-hub/issues/114)) ([950358f](https://github.com/luisbarcia/n8n-nodes-brasil-hub/commit/950358fd08b4bc4c6ba49256da9718bae11a3330))
 
-## [Unreleased]
-
 ## [1.1.1] - 2026-03-19
 
 ### Changed
@@ -575,7 +573,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependabot configuration (npm + GitHub Actions weekly updates)
 - MIT license
 
-[Unreleased]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.1.1...HEAD
 [1.1.1]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.3...v1.1.0
 [1.0.3]: https://github.com/luisbarcia/n8n-nodes-brasil-hub/compare/v1.0.2...v1.0.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Community n8n node (`n8n-nodes-brasil-hub`) that centralizes Brazilian public data queries. A single "Brasil Hub" node with extensible resources — v1.0.x ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Holiday (Feriados), FIPE, IBGE, and NCM — 9 resources, 17 operations, 22 providers, configurable timeout, configurable provider order, rate limit awareness, CNPJ output mode.
+Community n8n node (`n8n-nodes-brasil-hub`) that centralizes Brazilian public data queries. A single "Brasil Hub" node with extensible resources — v1.4.x ships CNPJ (7 providers), CEP (4 providers), CPF, Banks, DDD, Holiday (Feriados), FIPE, IBGE, NCM, PIX, Câmbio, Taxas, and Fake — 13 resources, 28 operations, 25 providers, configurable timeout, configurable provider order, rate limit awareness, CNPJ output mode.
 
 - **License:** MIT
 - **Tech Stack:** TypeScript, n8n-workflow, Jest + ts-jest
@@ -47,45 +47,36 @@ nodes/BrasilHub/
 ├── brasilHub.svg                # Icon
 ├── types.ts                     # ICnpjResult, ICepResult, IFipe*, IMeta, IValidationResult
 ├── resources/
-│   ├── cnpj/
-│   │   ├── cnpj.description.ts  # INodeProperties[]
-│   │   ├── cnpj.execute.ts      # { query, validate }
-│   │   └── cnpj.normalize.ts    # Provider response → normalized schema
-│   ├── cep/
-│   │   ├── cep.description.ts
-│   │   ├── cep.execute.ts
-│   │   └── cep.normalize.ts
-│   ├── cpf/
-│   │   ├── cpf.description.ts   # Validate only (no query — local checksum)
-│   │   └── cpf.execute.ts
-│   ├── banks/
-│   │   ├── banks.description.ts # Query + List operations
-│   │   ├── banks.execute.ts
-│   │   └── banks.normalize.ts   # BrasilAPI + BancosBrasileiros
-│   ├── ddd/
-│   │   ├── ddd.description.ts
-│   │   ├── ddd.execute.ts
-│   │   └── ddd.normalize.ts     # BrasilAPI + municipios-brasileiros
-│   └── fipe/
-│       ├── fipe.description.ts  # Brands, Models, Years, Price operations
-│       ├── fipe.execute.ts      # 4 hierarchical operations (parallelum)
-│       └── fipe.normalize.ts    # normalizeBrands, normalizeModels, normalizeYears, normalizePrice
+│   ├── banks/                   # Query + List (BrasilAPI → BancosBrasileiros)
+│   ├── cambio/                  # List Currencies + Query Rate (BrasilAPI/BCB)
+│   ├── cep/                     # Query + Validate (BrasilAPI → ViaCEP → OpenCEP → ApiCEP)
+│   ├── cnpj/                    # Query + Validate (7 providers)
+│   ├── cpf/                     # Validate only (local checksum)
+│   ├── ddd/                     # Query (BrasilAPI → municipios-brasileiros)
+│   ├── fake/                    # Person, Company, CPF, CNPJ (local, no API)
+│   ├── feriados/                # Query (BrasilAPI → Nager.Date)
+│   ├── fipe/                    # Brands, Models, Years, Price, Ref Tables (parallelum)
+│   ├── ibge/                    # States + Cities (BrasilAPI → IBGE API)
+│   ├── ncm/                     # Query + Search (BrasilAPI)
+│   ├── pix/                     # List + Query (BrasilAPI)
+│   └── taxas/                   # List + Query (BrasilAPI)
 ├── shared/
 │   ├── fallback.ts              # Generic multi-provider fallback (10s timeout)
+│   ├── utils.ts                 # Shared utilities (buildMeta, buildResultItem, safeStr)
+│   ├── description-builders.ts  # Shared UI field builders (includeRawField)
 │   └── validators.ts            # CNPJ/CPF checksum, CEP format validation (local, no API)
 ```
 
 ### Router Pattern
 
 ```typescript
-const resourceOperations: Record<string, Record<string, ExecuteFunction>> = {
-  cnpj: { query: cnpjQuery, validate: cnpjValidate },
-  cep:  { query: cepQuery,  validate: cepValidate },
-  cpf:  { validate: cpfValidate },
-  banks: { query: banksQuery, list: banksList },
-  ddd:  { query: dddQuery },
-  fipe: { brands: fipeBrands, models: fipeModels, years: fipeYears, price: fipePrice },
-};
+// Built automatically from barrel-exported resource modules (IResourceDefinition[])
+const allResources: IResourceDefinition[] = [
+  banksResource, cambioResource, cepResource, cnpjResource, cpfResource,
+  dddResource, fakeResource, feriadosResource, fipeResource, ibgeResource,
+  ncmResource, pixResource, taxasResource,
+];
+const resourceOperations = Object.fromEntries(allResources.map(r => [r.resource, r.operations]));
 ```
 
 The `execute()` method reads `resource` + `operation` params and dispatches to the correct handler.
@@ -104,9 +95,14 @@ Zero changes to existing resource files — only the router registration.
 **CNPJ:** BrasilAPI → CNPJ.ws → ReceitaWS → MinhaReceita → OpenCNPJ.org → OpenCNPJ.com → CNPJA
 **CEP:** BrasilAPI → ViaCEP → OpenCEP → ApiCEP
 **Banks:** BrasilAPI → BancosBrasileiros
+**Câmbio:** BrasilAPI (BCB data)
 **DDD:** BrasilAPI → municipios-brasileiros
 **Holiday (Feriados):** BrasilAPI → Nager.Date
 **FIPE:** parallelum (single provider — hierarchy API)
+**IBGE:** BrasilAPI → IBGE API
+**NCM:** BrasilAPI
+**PIX:** BrasilAPI
+**Taxas:** BrasilAPI
 
 Fallback is automatic. BrasilAPI is always primary. Headers include `User-Agent: n8n-brasil-hub-node/1.0`. Timeout is configurable per-node (default 10s, range 1–60s).
 
@@ -130,7 +126,7 @@ Fallback is automatic. BrasilAPI is always primary. Headers include `User-Agent:
 - Após adicionar/modificar código: rodar `/code-documenter` para verificar cobertura
 - **Nunca commitar código exportado sem JSDoc** — isso é parte do checklist de qualidade
 
-Status atual: **92/92 exports documentados (100%)**.
+Status atual: **108/108 exports documentados (100%)**.
 
 ## n8n Compliance
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Brasil Hub for n8n</h1>
 
 <p align="center">
-  Query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM, PIX) + generate fake test data — automatic multi-provider fallback, zero credentials.
+  Query Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM, PIX, Câmbio, Taxas) + generate fake test data — automatic multi-provider fallback, zero credentials.
 </p>
 
 <p align="center">
@@ -23,7 +23,7 @@
 
 ---
 
-> **v1.3** — 11 resources, 24 operations, 23 providers + local fake data generation. The API is stable and follows semantic versioning.
+> **v1.4** — 13 resources, 28 operations, 25 providers + local fake data generation. The API is stable and follows semantic versioning.
 
 ---
 
@@ -52,6 +52,8 @@ npm install n8n-nodes-brasil-hub
 |----------|-----------|-------------|-----------|
 | **Bank** | Query | Fetch bank info by COMPE code | BrasilAPI → BancosBrasileiros |
 | **Bank** | List | List all Brazilian banks | BrasilAPI → BancosBrasileiros |
+| **Câmbio** | List Currencies | List all available currencies from the Central Bank | BrasilAPI |
+| **Câmbio** | Query Rate | Fetch exchange rate quotations by currency and date | BrasilAPI |
 | **CEP** | Query | Fetch address data by CEP number | BrasilAPI → ViaCEP → OpenCEP → ApiCEP |
 | **CEP** | Validate | Check if CEP format is valid (local, no API) | — |
 | **CNPJ** | Query | Fetch company data by CNPJ number | BrasilAPI → CNPJ.ws → ReceitaWS → MinhaReceita → OpenCNPJ.org → OpenCNPJ.com → CNPJA |
@@ -74,6 +76,8 @@ npm install n8n-nodes-brasil-hub
 | **NCM** | Search | Search tax codes by description | BrasilAPI |
 | **PIX** | List | List all PIX participants | BrasilAPI |
 | **PIX** | Query | Look up PIX participant by ISPB code | BrasilAPI |
+| **Taxas** | List | List all available Brazilian interest rates | BrasilAPI |
+| **Taxas** | Query | Query a specific interest rate by code (Selic, CDI, IPCA) | BrasilAPI |
 
 ## Example Output
 
@@ -192,7 +196,7 @@ n8n 1.0+ with Node.js 20 or 22. The node follows semantic versioning -- minor up
 git clone https://github.com/luisbarcia/n8n-nodes-brasil-hub.git
 cd n8n-nodes-brasil-hub
 npm install
-npm test          # 1349 tests, 99%+ coverage
+npm test          # 1626 tests, 99%+ coverage
 npm run build
 npm run lint
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-brasil-hub",
   "version": "1.4.0",
-  "description": "n8n community node for Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM, PIX) + fake data generator — 23 providers, automatic fallback, AI Agent ready",
+  "description": "n8n community node for Brazilian public data (CNPJ, CEP, CPF, Banks, DDD, Holidays, FIPE, IBGE, NCM, PIX, Câmbio, Taxas) + fake data generator — 25 providers, automatic fallback, AI Agent ready",
   "license": "MIT",
   "homepage": "https://github.com/luisbarcia/n8n-nodes-brasil-hub",
   "keywords": [
@@ -43,7 +43,13 @@
     "fake-data",
     "test-data",
     "generator",
-    "faker"
+    "faker",
+    "cambio",
+    "exchange-rate",
+    "taxas",
+    "interest-rate",
+    "selic",
+    "cdi"
   ],
   "author": {
     "name": "Luis Barcia",


### PR DESCRIPTION
## Summary
- Propagate Câmbio + Taxas additions across all 7 living docs
- Update counts: 11→13 resources, 24→28 operations, 23→25 providers
- Update test count: 1349→1626, JSDoc: 92→108/108
- Add 6 npm keywords (cambio, exchange-rate, taxas, interest-rate, selic, cdi)
- Remove orphaned `[Unreleased]` section from CHANGELOG
- Update SECURITY.md supported versions (1.3.x→1.4.x)
- Update CONTRIBUTING.md project structure (5→13 resource dirs)

## Test plan
- [ ] Verify all 7 files reflect v1.4.0 state
- [ ] No broken markdown links in CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)