### PR TITLE
fix: resolve 16 SonarCloud issues (1 critical, 15 minor)

### DIFF
--- a/nodes/BrasilHub/resources/cambio/cambio.execute.ts
+++ b/nodes/BrasilHub/resources/cambio/cambio.execute.ts
@@ -56,8 +56,10 @@ export async function cambioRate(
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
 	const { includeRaw, timeoutMs } = readCommonParams(context, itemIndex);
-	const currencyCode = String(context.getNodeParameter('currencyCode', itemIndex) ?? '').trim().toUpperCase();
-	const date = String(context.getNodeParameter('date', itemIndex) ?? '').trim();
+	const rawCurrency = context.getNodeParameter('currencyCode', itemIndex);
+	const currencyCode = (rawCurrency != null ? String(rawCurrency) : '').trim().toUpperCase();
+	const rawDate = context.getNodeParameter('date', itemIndex);
+	const date = (rawDate != null ? String(rawDate) : '').trim();
 
 	if (!currencyCode || !CURRENCY_CODE_PATTERN.test(currencyCode)) {
 		throw new NodeOperationError(

--- a/nodes/BrasilHub/resources/cnpj/cnpj.normalize.ts
+++ b/nodes/BrasilHub/resources/cnpj/cnpj.normalize.ts
@@ -168,7 +168,7 @@ function normalizeMinhaReceita(data: Record<string, unknown>): ICnpjResult {
 		natureza_juridica: safeStr(data.natureza_juridica),
 		capital_social: safeCapital(data.capital_social),
 		atividade_principal: {
-			codigo: data.cnae_fiscal != null ? String(data.cnae_fiscal) : '',
+			codigo: data.cnae_fiscal == null ? '' : String(data.cnae_fiscal),
 			descricao: safeStr(data.cnae_fiscal_descricao),
 		},
 		endereco: {
@@ -206,7 +206,7 @@ function normalizeOpenCnpjOrg(data: Record<string, unknown>): ICnpjResult {
 
 	const rawCapital = data.capital_social;
 	const capitalSocial = typeof rawCapital === 'string'
-		? parseFloat(rawCapital.replaceAll('.', '').replace(',', '.')) || 0
+		? Number.parseFloat(rawCapital.replaceAll('.', '').replaceAll(',', '.')) || 0
 		: safeCapital(rawCapital);
 
 	return {
@@ -246,7 +246,7 @@ function normalizeOpenCnpjOrg(data: Record<string, unknown>): ICnpjResult {
 
 /** Maps OpenCNPJ.com wrapped camelCase response to {@link ICnpjResult}. */
 function normalizeOpenCnpjCom(raw: Record<string, unknown>): ICnpjResult {
-	const data = ((raw as Record<string, unknown>).data ?? raw) as Record<string, unknown>;
+	const data = ((raw.data ?? raw) as Record<string, unknown>);
 	const socios = Array.isArray(data.socios) ? data.socios : [];
 	return {
 		cnpj: safeStr(data.cnpj),
@@ -312,7 +312,7 @@ function normalizeCnpja(data: Record<string, unknown>): ICnpjResult {
 		natureza_juridica: safeStr(nature.text),
 		capital_social: safeCapital(company.equity),
 		atividade_principal: {
-			codigo: mainActivity.id != null ? String(mainActivity.id) : '',
+			codigo: mainActivity.id == null ? '' : String(mainActivity.id),
 			descricao: safeStr(mainActivity.text),
 		},
 		endereco: {

--- a/nodes/BrasilHub/resources/fake/fake.generators.ts
+++ b/nodes/BrasilHub/resources/fake/fake.generators.ts
@@ -30,7 +30,7 @@ function randDigits(n: number): string {
 
 /** Removes accents and special characters, lowercases. */
 function simplify(str: string): string {
-	return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '.');
+	return str.normalize('NFD').replaceAll(/[\u0300-\u036f]/g, '').toLowerCase().replaceAll(/\s+/g, '.');
 }
 
 // ─── CPF Generator ──────────────────────────────────────────────

--- a/nodes/BrasilHub/resources/fipe/fipe.execute.ts
+++ b/nodes/BrasilHub/resources/fipe/fipe.execute.ts
@@ -85,7 +85,10 @@ export async function fipeReferenceTables(
 	const allRaw = Array.isArray(data) ? data as Array<Record<string, unknown>> : [];
 	// Filter raw items to stay aligned with normalized tables when year filter is active
 	const rawItems = (filterYear >= 1000 && filterYear <= 9999)
-		? allRaw.filter((r) => String(r.Mes ?? '').endsWith(`/${String(filterYear)}`))
+		? allRaw.filter((r) => {
+			const mes = typeof r.Mes === 'string' ? r.Mes : '';
+			return mes.endsWith(`/${String(filterYear)}`);
+		})
 		: allRaw;
 	const meta = buildMeta('parallelum', 'referencias', [], false);
 

--- a/nodes/BrasilHub/resources/pix/pix.execute.ts
+++ b/nodes/BrasilHub/resources/pix/pix.execute.ts
@@ -51,7 +51,8 @@ export async function pixQuery(
 	context: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
-	const ispb = String(context.getNodeParameter('ispb', itemIndex) ?? '').replace(/\D/g, '');
+	const rawIspb = context.getNodeParameter('ispb', itemIndex);
+	const ispb = (rawIspb != null ? String(rawIspb) : '').replaceAll(/\D/g, '');
 	const { includeRaw, timeoutMs } = readCommonParams(context, itemIndex);
 
 	if (!ISPB_PATTERN.test(ispb)) {

--- a/nodes/BrasilHub/resources/taxas/taxas.execute.ts
+++ b/nodes/BrasilHub/resources/taxas/taxas.execute.ts
@@ -52,7 +52,8 @@ export async function taxasQuery(
 	context: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<INodeExecutionData[]> {
-	const rateCode = String(context.getNodeParameter('rateCode', itemIndex) ?? '').trim();
+	const rawRateCode = context.getNodeParameter('rateCode', itemIndex);
+	const rateCode = (rawRateCode != null ? String(rawRateCode) : '').trim();
 	const { includeRaw, timeoutMs } = readCommonParams(context, itemIndex);
 
 	if (!rateCode || !RATE_CODE_PATTERN.test(rateCode)) {

--- a/nodes/BrasilHub/shared/fallback.ts
+++ b/nodes/BrasilHub/shared/fallback.ts
@@ -17,6 +17,38 @@ export function clampTimeout(value: number): number {
 }
 
 /**
+ * Extracts rate-limit info from an HTTP error when the status is 429.
+ *
+ * @param error - The caught error object from httpRequest.
+ * @returns Object with `rateLimited` flag and optional `retryAfterMs`.
+ */
+function extractRateLimitInfo(error: unknown): { rateLimited: boolean; retryAfterMs?: number } {
+	const httpCode = String((error as Record<string, unknown>)?.httpCode ?? '');
+	if (httpCode !== '429') {
+		return { rateLimited: false };
+	}
+
+	const retryHeader = (error as Record<string, Record<string, unknown>>)?.headers?.['retry-after'];
+	if (retryHeader == null) {
+		return { rateLimited: true };
+	}
+
+	const seconds = Number(retryHeader);
+	const retryAfterMs = Number.isFinite(seconds) && seconds > 0
+		? Math.round(seconds * 1000)
+		: undefined;
+	return { rateLimited: true, retryAfterMs };
+}
+
+/** Formats an error message with optional HTTP status code prefix. */
+function formatProviderError(providerName: string, error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	const httpCode = String((error as Record<string, unknown>)?.httpCode ?? '');
+	const detail = httpCode ? `[${httpCode}] ${message}` : message;
+	return `${providerName}: ${detail}`;
+}
+
+/**
  * Queries multiple providers in sequence until one succeeds (fallback strategy).
  *
  * Tries each provider in order. Uses n8n's `httpRequest` helper with a
@@ -53,19 +85,13 @@ export async function queryWithFallback(
 
 			return { data, provider: provider.name, errors, rateLimited, retryAfterMs };
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			const httpCode = (error as Record<string, unknown>)?.httpCode;
-			const detail = httpCode ? `[${httpCode}] ${message}` : message;
-			errors.push(`${provider.name}: ${detail}`);
+			errors.push(formatProviderError(provider.name, error));
 
-			if (httpCode === 429 || httpCode === '429') {
+			const rateInfo = extractRateLimitInfo(error);
+			if (rateInfo.rateLimited) {
 				rateLimited = true;
-				const retryHeader = (error as Record<string, Record<string, unknown>>)?.headers?.['retry-after'];
-				if (retryHeader != null) {
-					const seconds = Number(retryHeader);
-					if (Number.isFinite(seconds) && seconds > 0) {
-						retryAfterMs = Math.round(seconds * 1000);
-					}
+				if (rateInfo.retryAfterMs !== undefined) {
+					retryAfterMs = rateInfo.retryAfterMs;
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- **Critical**: Reduce `queryWithFallback` cognitive complexity from 23 to ~10 by extracting `extractRateLimitInfo` and `formatProviderError` helpers
- **Minor (15)**: Object stringification, `parseFloat` → `Number.parseFloat`, `replace` → `replaceAll`, negated conditions, unnecessary assertion

## Files changed
- `shared/fallback.ts` — extract 2 helpers, reduce cognitive complexity
- `cambio/cambio.execute.ts` — safe param reading
- `taxas/taxas.execute.ts` — safe param reading
- `pix/pix.execute.ts` — safe param reading + replaceAll
- `cnpj/cnpj.normalize.ts` — 4 fixes (parseFloat, assertion, negated conditions)
- `fake/fake.generators.ts` — replace → replaceAll
- `fipe/fipe.execute.ts` — safe string access

## Test plan
- [x] 1626 tests passing
- [x] Lint clean (0 errors)
- [ ] SonarCloud Quality Gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)